### PR TITLE
Minify Debug Mode: CSS line numbers debug data problem when source contatins comment with url

### DIFF
--- a/lib/Minify/Minify/Lines.php
+++ b/lib/Minify/Minify/Lines.php
@@ -95,7 +95,7 @@ class Minify_Lines {
     private static function _eolInComment($line, $inComment)
     {
         // crude way to avoid things like // */
-        $line = preg_replace('~//.*?(\\*/|/\\*).*~', '', $line);
+        $line = preg_replace('~(?<!:)//.*?(\\*/|/\\*).*~', '', $line);
 
         while (strlen($line)) {
             $search = $inComment


### PR DESCRIPTION
If you have a block comment in one line with an url inside it, the code incorrectly thinks the comment is not finished.

This is due to the double slash in http:// that gets trim if at the same line there is an */ following it.

For example, this line:

/* Generated by Font Squirrel (http://www.fontsquirrel.com) on May 30, 2013 */

Gets converted to:

/* Generated by Font Squirrel (http:

So it thinks the comment is not finished.

That behaviour breaks web rendering because large portions of valid CSS get deactivated inside a comment when combining them inside the big css with line comments.

