### PR TITLE
add config to make memcached binary protocol optional

### DIFF
--- a/Cache_Memcached.php
+++ b/Cache_Memcached.php
@@ -59,8 +59,12 @@ class Cache_Memcached extends Cache_Base {
 		if ( defined( '\Memcached::OPT_REMOVE_FAILED_SERVERS' ) ) {
 			$this->_memcache->setOption( \Memcached::OPT_REMOVE_FAILED_SERVERS, true );
 		}
-		if ( defined( '\Memcached::OPT_BINARY_PROTOCOL' ) && defined( '\Memcached::OPT_TCP_NODELAY' ) ) {
+
+		if ( isset( $config['binary_protocol'] ) && !empty( $config['binary_protocol'] ) && defined( '\Memcached::OPT_BINARY_PROTOCOL' ) ) {
 			$this->_memcache->setOption( \Memcached::OPT_BINARY_PROTOCOL, true );
+		}
+
+		if ( defined( '\Memcached::OPT_TCP_NODELAY' ) ) {
 			$this->_memcache->setOption( \Memcached::OPT_TCP_NODELAY, true );
 		}
 

--- a/ConfigCompiler.php
+++ b/ConfigCompiler.php
@@ -387,6 +387,8 @@ class ConfigCompiler {
 			'fragmentcache', 'memcached.username' );
 		$this->_set_if_exists( $file_data, 'fragmentcache.memcached.password',
 			'fragmentcache', 'memcached.password' );
+		$this->_set_if_exists( $file_data, 'fragmentcache.memcached.binary_protocol',
+			'fragmentcache', 'memcached.binary_protocol' );
 		$this->_set_if_exists( $file_data, 'fragmentcache.redis.persistent',
 			'fragmentcache', 'redis.persistent' );
 		$this->_set_if_exists( $file_data, 'fragmentcache.redis.servers',

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -83,6 +83,10 @@ $keys = array(
 		'type' => 'string',
 		'default' => ''
 	),
+	'dbcache.memcached.binary_protocol' => array(
+		'type' => 'boolean',
+		'default' => true
+	),
 	'dbcache.redis.persistent' => array(
 		'type' => 'boolean',
 		'default' => true
@@ -207,6 +211,10 @@ $keys = array(
 		'type' => 'string',
 		'default' => ''
 	),
+	'objectcache.memcached.binary_protocol' => array(
+		'type' => 'boolean',
+		'default' => true
+	),
 	'objectcache.redis.persistent' => array(
 		'type' => 'boolean',
 		'default' => true
@@ -315,6 +323,10 @@ $keys = array(
 	'pgcache.memcached.password' => array(
 		'type' => 'string',
 		'default' => ''
+	),
+	'pgcache.memcached.binary_protocol' => array(
+		'type' => 'boolean',
+		'default' => true
 	),
 	'pgcache.redis.persistent' => array(
 		'type' => 'boolean',
@@ -681,6 +693,10 @@ $keys = array(
 	'minify.memcached.password' => array(
 		'type' => 'string',
 		'default' => ''
+	),
+	'minify.memcached.binary_protocol' => array(
+		'type' => 'boolean',
+		'default' => true
 	),
 	'minify.redis.persistent' => array(
 		'type' => 'boolean',

--- a/DbCache_Core.php
+++ b/DbCache_Core.php
@@ -16,7 +16,8 @@ class DbCache_Core {
 				'persistent' => $c->get_boolean( 'dbcache.memcached.persistent' ),
 				'aws_autodiscovery' => $c->get_boolean( 'dbcache.memcached.aws_autodiscovery' ),
 				'username' => $c->get_string( 'dbcache.memcached.username' ),
-				'password' => $c->get_string( 'dbcache.memcached.password' )
+				'password' => $c->get_string( 'dbcache.memcached.password' ),
+				'binary_protocol' => $c->get_boolean( 'dbcache.memcached.binary_protocol' )
 			);
 			break;
 

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -338,7 +338,8 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 					'persistent' => $this->_config->get_boolean( 'dbcache.memcached.persistent' ),
 					'aws_autodiscovery' => $this->_config->get_boolean( 'dbcache.memcached.aws_autodiscovery' ),
 					'username' => $this->_config->get_string( 'dbcache.memcached.username' ),
-					'password' => $this->_config->get_string( 'dbcache.memcached.password' )
+					'password' => $this->_config->get_string( 'dbcache.memcached.password' ),
+					'binary_protocol' => $c->get_boolean( 'dbcache.memcached.binary_protocol' )
 				);
 				break;
 

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -651,7 +651,8 @@ class Minify_MinifiedFileRequestHandler {
 					'persistent' => $this->_config->get_boolean( 'minify.memcached.persistent' ),
 					'aws_autodiscovery' => $this->_config->get_boolean( 'minify.memcached.aws_autodiscovery' ),
 					'username' => $this->_config->get_string( 'minify.memcached.username' ),
-					'password' => $this->_config->get_string( 'minify.memcached.password' )
+					'password' => $this->_config->get_string( 'minify.memcached.password' ),
+					'binary_protocol' => $this->_config->get_boolean( 'minify.memcached.binary_protocol' )
 				);
 				if ( class_exists( 'Memcached' ) ) {
 					$inner_cache = new Cache_Memcached( $config );

--- a/Minify_Plugin_Admin.php
+++ b/Minify_Plugin_Admin.php
@@ -188,6 +188,7 @@ class Minify_Plugin_Admin {
 				'servers' => $c->get_array( 'minify.memcached.servers' ),
 				'username' => $c->get_string( 'minify.memcached.username' ),
 				'password' => $c->get_string( 'minify.memcached.password' ),
+				'binary_protocol' => $c->get_boolean( 'minify.memcached.binary_protocol' ),
 				'name' => __( 'Minification', 'w3-total-cache' )
 			);
 		} elseif ( $c->get_string( 'minify.engine' ) == 'redis' ) {

--- a/ObjectCache_Plugin.php
+++ b/ObjectCache_Plugin.php
@@ -314,6 +314,7 @@ class ObjectCache_Plugin {
 				'servers' => $c->get_array( 'objectcache.memcached.servers' ),
 				'username' => $c->get_string( 'objectcache.memcached.username' ),
 				'password' => $c->get_string( 'objectcache.memcached.password' ),
+				'binary_protocol' => $c->get_boolean( 'objectcache.memcached.binary_protocol' ),
 				'name' => __( 'Object Cache', 'w3-total-cache' )
 			);
 		} elseif ( $c->get_string( 'objectcache.engine' ) == 'redis' ) {

--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -685,7 +685,8 @@ class ObjectCache_WpObjectCache_Regular {
 				'persistent' => $this->_config->get_boolean( 'objectcache.memcached.persistent' ),
 				'aws_autodiscovery' => $this->_config->get_boolean( 'objectcache.memcached.aws_autodiscovery' ),
 				'username' => $this->_config->get_string( 'objectcache.memcached.username' ),
-				'password' => $this->_config->get_string( 'objectcache.memcached.password' )
+				'password' => $this->_config->get_string( 'objectcache.memcached.password' ),
+				'binary_protocol' => $this->_config->get_boolean( 'objectcache.memcached.binary_protocol' )
 			);
 			break;
 
@@ -732,7 +733,8 @@ class ObjectCache_WpObjectCache_Regular {
 						'objectcache.memcached.persistent' ),
 					'aws_autodiscovery' => $this->_config->get_boolean( 'objectcache.memcached.aws_autodiscovery' ),
 					'username' => $this->_config->get_string( 'objectcache.memcached.username' ),
-					'password' => $this->_config->get_string( 'objectcache.memcached.password' )
+					'password' => $this->_config->get_string( 'objectcache.memcached.password' ),
+					'binary_protocol' => $this->_config->get_boolean( 'objectcache.memcached.binary_protocol' )
 				);
 				break;
 

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -758,7 +758,8 @@ class PgCache_ContentGrabber {
 				'persistent' => $this->_config->get_boolean( 'pgcache.memcached.persistent' ),
 				'aws_autodiscovery' => $this->_config->get_boolean( 'pgcache.memcached.aws_autodiscovery' ),
 				'username' => $this->_config->get_string( 'pgcache.memcached.username' ),
-				'password' => $this->_config->get_string( 'pgcache.memcached.password' )
+				'password' => $this->_config->get_string( 'pgcache.memcached.password' ),
+				'binary_protocol' => $this->_config->get_boolean( 'pgcache.memcached.binary_protocol' )
 			);
 			break;
 
@@ -802,7 +803,8 @@ class PgCache_ContentGrabber {
 					'persistent' => $this->_config->get_boolean( 'pgcache.memcached.persistent' ),
 					'aws_autodiscovery' => $this->_config->get_boolean( 'pgcache.memcached.aws_autodiscovery' ),
 					'username' => $this->_config->get_string( 'pgcache.memcached.username' ),
-					'password' => $this->_config->get_string( 'pgcache.memcached.password' )
+					'password' => $this->_config->get_string( 'pgcache.memcached.password' ),
+					'binary_protocol' => $this->_config->get_boolean( 'pgcache.memcached.binary_protocol' )
 				);
 				break;
 

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -274,6 +274,7 @@ class PgCache_Plugin {
 				'servers' => $c->get_array( 'pgcache.memcached.servers' ),
 				'username' => $c->get_string( 'pgcache.memcached.username' ),
 				'password' => $c->get_string( 'pgcache.memcached.password' ),
+				'binary_protocol' => $c->get_boolean( 'pgcache.memcached.binary_protocol' ),
 				'name' => __( 'Page Cache', 'w3-total-cache' )
 			);
 		} elseif ( $c->get_string( 'pgcache.engine' ) == 'redis' ) {

--- a/Util_ConfigLabel.php
+++ b/Util_ConfigLabel.php
@@ -10,6 +10,7 @@ class Util_ConfigLabel {
 				'memcached.persistent' => __( 'Persistent connection', 'w3-total-cache' ),
 				'memcached.username' => __( 'Memcached username:', 'w3-total-cache' ),
 				'memcached.password' => __( 'Memcached password:', 'w3-total-cache' ),
+				'memcached.binary_protocol' => __( 'Binary protocol', 'w3-total-cache' ),
 				'redis.servers' => __( 'Redis hostname:port / <acronym title="Internet Protocol">IP</acronym>:port:', 'w3-total-cache' ),
 				'redis.persistent' => __( 'Persistent connection', 'w3-total-cache' ),
 				'redis.dbid' => __( 'Redis Database ID:', 'w3-total-cache' ),

--- a/inc/options/parts/memcached.php
+++ b/inc/options/parts/memcached.php
@@ -45,6 +45,13 @@ else
 		</span>
 	</td>
 </tr>
+<tr>
+	<th><label><?php _e( 'Use binary protocol:', 'w3-total-cache' ); ?></label></th>
+	<td>
+		<?php $this->checkbox( $module . '.memcached.binary_protocol' ) ?> <?php echo Util_ConfigLabel::get( 'memcached.binary_protocol' ) ?></label><br />
+		<span class="description"><?php _e( 'Using binary protocol can increase throughput.', 'w3-total-cache' ); ?></span>
+	</td>
+</tr>
 
 <tr>
 	<th><label for="memcached_username"><?php echo Util_ConfigLabel::get( 'memcached.username' ) ?></label></th>


### PR DESCRIPTION
w3-total-cache fails to connect to memcached servers with binary protocol turned on.

The cause of this issue is the `\Memcached::OPT_BINARY_PROTOCOL` constant which is defined if there is support for this feature on the server running the Wordpress instance. It is however possible that the actual memcached server instance, or a proxy in between does not support it.

This change adds a config option to disable the binary protocol for memcached.

I'm not a 100% sure I updated all the relevant parts to support this new config. The core functionality is tested and works for us. This setting appears in the Admin interface and is editable there. Feedback is welcome!