### PR TITLE
Add rel attribute 'prefetch' on style tag builders

### DIFF
--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -643,8 +643,8 @@ class Minify_Plugin {
 			return "<style media=\"all\">@import url(\"" . $url . "\");</style>\r\n";
 		} elseif ( $import && !$use_style ) {
 			return "@import url(\"" . $url . "\");\r\n";
-		}else {
-			return "<link rel=\"stylesheet\" href=\"" . str_replace( '&', '&amp;', $url ) . "\" media=\"all\" />\r\n";
+		} else {
+			return "<link rel=\"prefetch stylesheet\" href=\"" . str_replace( '&', '&amp;', $url ) . "\" media=\"all\" />\r\n";
 		}
 	}
 
@@ -1228,7 +1228,7 @@ class _W3_MinifyHelpers {
 					$files, 'css' );
 				if ( !is_null( $return['url'] ) ) {
 					$return['body'] =
-						"<link rel=\"stylesheet\" href=\"" .
+						"<link rel=\"prefetch stylesheet\" href=\"" .
 						str_replace( '&', '&amp;', $return['url'] ) .
 						"\" media=\"all\" />\r\n";
 				}


### PR DESCRIPTION
Using 'prefetch' can be handy for performance bumps, similar to using 'defer' or 'async' on script tags. Google Lighthouse advised we 'Remove unused CSS' that was costing ~0.55s of load time. Some of the style was being added by w3-total-cache, that we use for forms later on, so we want to cache it. Adding 'prefetch' to these places did not cause any issues that we have found, and effectively deferred the style loading until the browser is freed up.

---

Link prefetching is a browser mechanism, which utilizes browser idle time to download or prefetch documents that the user might visit in the near future. A web page provides a set of prefetching hints to the browser, and after the browser is finished loading the page, it begins silently prefetching specified documents and stores them in its cache. When the user visits one of the prefetched documents, it can be served up quickly out of the browser's cache.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ