### PR TITLE
FAQ Link in Dashboard open in new tab

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -342,7 +342,8 @@ class Generic_Plugin {
 				'id' => 'w3tc_settings_faq',
 				'parent' => 'w3tc',
 				'title' => __( 'FAQ', 'w3-total-cache' ),
-				'href' => wp_nonce_url( network_admin_url( 'admin.php?page=w3tc_faq' ), 'w3tc' )
+				'href' => wp_nonce_url( network_admin_url( 'admin.php?page=w3tc_faq' ), 'w3tc' ),
+				'meta' => array( 'target' => '_blank' )
 			);
 
 			$menu_items['60010.generic'] = array(

--- a/Root_AdminMenu.php
+++ b/Root_AdminMenu.php
@@ -145,6 +145,7 @@ class Root_AdminMenu {
 
 				if ( isset( $titles['redirect_faq'] ) ) {
 					add_action( 'load-' . $hook, array( $this, 'redirect_faq' ) );
+					add_action( 'admin_head', array( $this, 'faq_target_blank') );
 				}
 			}
 		}
@@ -154,6 +155,16 @@ class Root_AdminMenu {
 	public function redirect_faq() {
 		wp_redirect( W3TC_FAQ_URL );
 		exit;
+	}
+
+	public function faq_target_blank(){
+?>
+		<script type="text/javascript">
+	        jQuery(document).ready( function($) {   
+	            $('#toplevel_page_w3tc_dashboard ul li').find('a[href*="w3tc_faq"]').prop('target','_blank');  
+	        });
+    	</script>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
Change FAQ link in left sidebar to open in a new tab via JQuery.
Change FAQ link on top admin bar to open in new tab with target attribute.
This commit fix issue #52