### PR TITLE
Add cr to htaccess

### DIFF
--- a/Util_Rule.php
+++ b/Util_Rule.php
@@ -224,36 +224,59 @@ class Util_Rule {
 	/**
 	 *
 	 *
-	 * @param Util_Environment_Exceptions $exs
-	 * @param string  $path
-	 * @param string  $rules
-	 * @param string  $start
-	 * @param string  $end
-	 * @param array   $order
+	 * @param Util_Environment_Exceptions $exs exceptions to fill on error
+	 * @param string  $path filename of rules file to modify
+	 * @param string  $rules rules to add
+	 * @param string  $start start marker
+	 * @param string  $end end marker
+	 * @param array   $order order where to place if some marker exists
+	 * @param boolean $remove_wpsc if WPSC rules should be removed to avoid
+	 *                  inconsistent rules generation
 	 */
-	static public function add_rules( $exs, $path, $rules, $start, $end, $order ) {
-		if ( empty( $path ) )
+	static public function add_rules( $exs, $path, $rules, $start, $end, $order,
+			$remove_wpsc = false ) {
+		if ( empty( $path ) ) {
 			return;
+		}
 
 		$data = @file_get_contents( $path );
-
-		if ( $data === false )
+		if ( empty( $data ) ) {
 			$data = '';
+		}
+
+		$modified = false;
+		if ( $remove_wpsc ) {
+			if ( Util_Rule::has_rules(
+					$data,
+					W3TC_MARKER_BEGIN_PGCACHE_WPSC,
+					W3TC_MARKER_END_PGCACHE_WPSC ) ) {
+				$data = Util_Rule::erase_rules(
+					$data,
+					W3TC_MARKER_BEGIN_PGCACHE_WPSC,
+					W3TC_MARKER_END_PGCACHE_WPSC );
+				$modified = true;
+			}
+		}
 
 		if ( empty( $rules ) ) {
-			$rules_present = ( strpos( $data, $start ) !==  false );
-			if ( !$rules_present )
+			// rules removal mode
+			$rules_present = ( strpos( $data, $start ) !== false );
+			if ( !$modified && !$rules_present ) {
 				return;
+			}
 		} else {
+			// rules creation mode
 			$rules_missing = ( strstr( Util_Rule::clean_rules( $data ), Util_Rule::clean_rules( $rules ) ) === false );
-			if ( !$rules_missing )
+			if ( !$modified && !$rules_missing ) {
 				return;
+			}
 		}
 
 		$replace_start = strpos( $data, $start );
 		$replace_end = strpos( $data, $end );
 
 		if ( $replace_start !== false && $replace_end !== false && $replace_start < $replace_end ) {
+			// old rules exists, replace mode
 			$replace_length = $replace_end - $replace_start + strlen( $end ) + 1;
 		} else {
 			$replace_start = false;
@@ -274,28 +297,31 @@ class Util_Rule {
 		if ( $replace_start !== false ) {
 			$data = Util_Rule::trim_rules( substr_replace( $data, $rules, $replace_start, $replace_length ) );
 		} else {
-			$data = Util_Rule::trim_rules( $data . $rules );
+			$data = Util_Rule::trim_rules( rtrim( $data ) . "\n" . $rules );
 		}
 
 		if ( strpos( $path, W3TC_CACHE_DIR ) === false || Util_Environment::is_nginx() ) {
+			// writing to system rules file, may be potentially write-protected
 			try {
 				Util_WpFile::write_to_file( $path, $data );
 			} catch ( Util_WpFile_FilesystemOperationException $ex ) {
-				if ( $replace_start !== false )
-					$exs->push( new Util_WpFile_FilesystemModifyException(
-							$ex->getMessage(), $ex->credentials_form(),
-							sprintf( __( 'Edit file <strong>%s
-                            </strong> and replace all lines between and including <strong>%s</strong> and
-                            <strong>%s</strong> markers with:', 'w3-total-caceh' ), $path, $start, $end ), $path, $rules ) );
-				else
-					$exs->push( new Util_WpFile_FilesystemModifyException(
-							$ex->getMessage(), $ex->credentials_form(),
-							sprintf( __( 'Edit file <strong>%s</strong> and add the following rules
-                                    above the WordPress directives:', 'w3-total-cache' ),
-								$path ), $path, $rules ) );
+				if ( $replace_start !== false ) {
+					$message = sprintf( __( 'Edit file <strong>%s</strong> and replace all lines between and including <strong>%s</strong> and <strong>%s</strong> markers with:',
+						'w3-total-caceh' ), $path, $start, $end );
+				} else {
+					$message = sprintf( __( 'Edit file <strong>%s</strong> and add the following rules above the WordPress directives:',
+						'w3-total-cache' ), $path );
+				}
+
+				$ex = new Util_WpFile_FilesystemModifyException(
+					$ex->getMessage(), $ex->credentials_form(),
+					$message, $path, $rules );
+
+				$exs->push( $ex );
 				return;
 			}
 		} else {
+			// writing to own rules file in cache folder
 			if ( !@file_exists( dirname( $path ) ) ) {
 				Util_File::mkdir_from( dirname( $path ), W3TC_CACHE_DIR );
 			}
@@ -351,7 +377,7 @@ class Util_Rule {
 			$exs->push( new Util_WpFile_FilesystemModifyException(
 					$ex->getMessage(), $ex->credentials_form(),
 					sprintf( __( 'Edit file <strong>%s</strong> and remove all lines between and including <strong>%s</strong>
-                and <strong>%s</strong> markers.', 'w3-total-cache' ), $path, $start, $end ), $path ) );
+				and <strong>%s</strong> markers.', 'w3-total-cache' ), $path, $start, $end ), $path ) );
 		}
 	}
 


### PR DESCRIPTION
When custom .htaccess is used with no trailing line, the configuration injected by W3TC didn't insert line break before adding own rules causing a corrupt .htaccess generation