### PR TITLE
Dont show html entities in news widget

### DIFF
--- a/Generic_Plugin_WidgetForum.php
+++ b/Generic_Plugin_WidgetForum.php
@@ -89,38 +89,17 @@ class Generic_Plugin_WidgetForum {
 		$items = array();
 		$items_count = $this->_config->get_integer( 'widget.latest.items' );
 
-		if ( $wp_version >= 2.8 ) {
-			include_once ABSPATH . WPINC . '/feed.php';
-			$feed = fetch_feed( W3TC_FEED_URL );
+		include_once ABSPATH . WPINC . '/feed.php';
+		$feed = fetch_feed( W3TC_FEED_URL );
 
-			if ( !is_wp_error( $feed ) ) {
-				$feed_items = $feed->get_items( 0, $items_count );
+		if ( !is_wp_error( $feed ) ) {
+			$feed_items = $feed->get_items( 0, $items_count );
 
-				foreach ( $feed_items as $feed_item ) {
-					$items[] = array(
-						'link' => $feed_item->get_link(),
-						'title' => $feed_item->get_title(),
-						'description' => $feed_item->get_description()
-					);
-				}
-			}
-		} else {
-			include_once ABSPATH . WPINC . '/rss.php';
-			$rss = fetch_rss( W3TC_FEED_URL );
-
-			if ( is_object( $rss ) ) {
-				$items = array_slice( $rss->items, 0, $items_count );
-			}
-		}
-
-		// Removes feedburner tracking images when site is https
-		if ( Util_Environment::is_https() ) {
-			$total = sizeof( $items );
-			for ( $i = 0; $i < $total; $i++ ) {
-				if ( isset( $items[$i]['description'] ) ) {
-					$items[$i]['description'] = preg_replace( '/<img[^>]+src[^>]+W3TOTALCACHE[^>]+>/',
-						'', $items[$i]['description'] );
-				}
+			foreach ( $feed_items as $feed_item ) {
+				$items[] = array(
+					'link' => $feed_item->get_link(),
+					'title' => htmlspecialchars_decode( $feed_item->get_title() )
+				);
 			}
 		}
 

--- a/Generic_Plugin_WidgetNews.php
+++ b/Generic_Plugin_WidgetNews.php
@@ -82,38 +82,17 @@ class Generic_Plugin_WidgetNews {
 		$items = array();
 		$items_count = $this->_config->get_integer( 'widget.latest_news.items' );
 
-		if ( $wp_version >= 2.8 ) {
-			include_once ABSPATH . WPINC . '/feed.php';
-			$feed = fetch_feed( W3TC_NEWS_FEED_URL );
+		include_once ABSPATH . WPINC . '/feed.php';
+		$feed = fetch_feed( W3TC_NEWS_FEED_URL );
 
-			if ( !is_wp_error( $feed ) ) {
-				$feed_items = $feed->get_items( 0, $items_count );
+		if ( !is_wp_error( $feed ) ) {
+			$feed_items = $feed->get_items( 0, $items_count );
 
-				foreach ( $feed_items as $feed_item ) {
-					$items[] = array(
-						'link' => $feed_item->get_link(),
-						'title' => $feed_item->get_title(),
-						'description' => $feed_item->get_description()
-					);
-				}
-			}
-		} else {
-			include_once ABSPATH . WPINC . '/rss.php';
-			$rss = fetch_rss( W3TC_NEWS_FEED_URL );
-
-			if ( is_object( $rss ) ) {
-				$items = array_slice( $rss->items, 0, $items_count );
-			}
-		}
-
-		// Removes feedburner tracking images when site is https
-		if ( Util_Environment::is_https() ) {
-			$total = sizeof( $items );
-			for ( $i = 0; $i < $total; $i++ ) {
-				if ( isset( $items[$i]['description'] ) ) {
-					$items[$i]['description'] = preg_replace( '/<img[^>]+src[^>]+W3TOTALCACHE[^>]+>/',
-						'', $items[$i]['description'] );
-				}
+			foreach ( $feed_items as $feed_item ) {
+				$items[] = array(
+					'link' => $feed_item->get_link(),
+					'title' => htmlspecialchars_decode( $feed_item->get_title() )
+				);
 			}
 		}
 

--- a/inc/widget/latest_ajax.php
+++ b/inc/widget/latest_ajax.php
@@ -7,9 +7,11 @@ if ( !defined( 'W3TC' ) )
 ?>
 <?php foreach ( $items as $item ): ?>
 <h4>
-	<a href="<?php echo $item['link']; ?>"><?php echo $item['title']; ?></a>
+	<a href="<?php echo esc_url( $item['link'] ) ?>">
+		<?php echo esc_html( wp_strip_all_tags( $item['title'] ) ) ?>
+	</a>
 </h4>
-<?php endforeach; ?>
+<?php endforeach ?>
 
 <p style="text-align: center;">
 	<a href="<?php echo W3TC_FEED_URL; ?>" target="_blank">View Feed</a>

--- a/inc/widget/latest_news_ajax.php
+++ b/inc/widget/latest_news_ajax.php
@@ -7,9 +7,11 @@ if ( !defined( 'W3TC' ) )
 ?>
 <?php foreach ( $items as $item ): ?>
 <h4>
-	<a href="<?php echo $item['link']; ?>"><?php echo $item['title']; ?></a>
+	<a href="<?php echo esc_url( $item['link'] ) ?>">
+		<?php echo esc_html( wp_strip_all_tags( $item['title'] ) ) ?>
+	</a>
 </h4>
-<?php endforeach; ?>
+<?php endforeach ?>
 
 <p style="text-align: center;">
 	<a href="<?php echo W3TC_NEWS_FEED_URL; ?>" target="_blank">View Feed</a>


### PR DESCRIPTION
Widgets printed html-escaped <div>content</div> coming from news feed