### PR TITLE
when wp-content/cache folder is removed - it was not created by frontend

### DIFF
--- a/Cache_File.php
+++ b/Cache_File.php
@@ -445,7 +445,7 @@ class Cache_File extends Cache_Base {
 		$dir = dirname( $path );
 
 		if ( !@is_dir( $dir ) ) {
-			if ( !Util_File::mkdir_from( $dir, W3TC_CACHE_DIR ) )
+			if ( !Util_File::mkdir_from( $dir, dirname( W3TC_CACHE_DIR ) ) )
 				return false;
 		}
 

--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -44,7 +44,7 @@ class Cache_File_Generic extends Cache_File {
 		$dir = dirname( $path );
 
 		if ( !@is_dir( $dir ) ) {
-			if ( !Util_File::mkdir_from_safe( $dir, W3TC_CACHE_DIR ) )
+			if ( !Util_File::mkdir_from_safe( $dir, dirname( W3TC_CACHE_DIR ) ) )
 				return false;
 		}
 


### PR DESCRIPTION
Plugin didn't try to create wp-content/cache folder itself during front-end requests processing, only folders below it.

That makes deployment scripts more complex.