### PR TITLE
protection from invalid regex in reject.uri option, fixes #142

### DIFF
--- a/PgCache_Page.php
+++ b/PgCache_Page.php
@@ -4,6 +4,14 @@ namespace W3TC;
 
 
 class PgCache_Page extends Base_Page_Settings {
+	static public function admin_print_scripts_w3tc_pgcache() {
+		wp_enqueue_script( 'w3tc-options-validator',
+			plugins_url( 'pub/js/options-validator.js', W3TC_FILE ),
+			array(), W3TC_VERSION );
+	}
+
+
+
 	/**
 	 * Current page
 	 *

--- a/PgCache_Plugin_Admin.php
+++ b/PgCache_Plugin_Admin.php
@@ -36,8 +36,14 @@ class PgCache_Plugin_Admin {
 					$this, 'w3tc_usage_statistics_summary_from_history' ), 10, 2 );
 		}
 
-		// cookie groups
 		add_filter( 'w3tc_admin_menu', array( $this, 'w3tc_admin_menu' ) );
+
+		add_action( 'admin_print_scripts-performance_page_w3tc_pgcache', array(
+				'\W3TC\PgCache_Page',
+				'admin_print_scripts_w3tc_pgcache'
+			) );
+
+		// cookie groups
 		add_action( 'admin_init_w3tc_pgcache_cookiegroups',	array(
 				'\W3TC\PgCache_Page_CookieGroups',
 				'admin_init_w3tc_pgcache_cookiegroups'

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -394,6 +394,7 @@ if ( $this->_config->get_string( 'pgcache.engine' ) == 'memcached' ||
 				<th><label for="pgcache_reject_uri"><?php Util_Ui::e_config_label( 'pgcache.reject.uri' ) ?></label></th>
 				<td>
 					<textarea id="pgcache_reject_uri" name="pgcache__reject__uri"
+						w3tc-data-validator="regexps"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 						cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'pgcache.reject.uri' ) ) ); ?></textarea>
 					<p class="description">
@@ -447,6 +448,7 @@ if ( $this->_config->get_string( 'pgcache.engine' ) == 'memcached' ||
 				<th><label for="pgcache_accept_files"><?php Util_Ui::e_config_label( 'pgcache.accept.files' ) ?></label></th>
 				<td>
 					<textarea id="pgcache_accept_files" name="pgcache__accept__files"
+						w3tc-data-validator="regexps"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 						cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'pgcache.accept.files' ) ) ); ?></textarea>
 					<p class="description"><?php echo sprintf( __( 'Cache the specified pages / directories even if listed in the "never cache the following pages" field. Supports regular expression (See <a href="%s"><acronym title="Frequently Asked Questions">FAQ</acronym></a>)', 'w3-total-cache' ), network_admin_url( 'admin.php?page=w3tc_faq' ) ); ?></p>
@@ -457,6 +459,7 @@ if ( $this->_config->get_string( 'pgcache.engine' ) == 'memcached' ||
 				<th><label for="pgcache_accept_uri"><?php Util_Ui::e_config_label( 'pgcache.accept.uri' ) ?></label></th>
 				<td>
 					<textarea id="pgcache_accept_uri" name="pgcache__accept__uri"
+						w3tc-data-validator="regexps"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 						cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'pgcache.accept.uri' ) ) ); ?></textarea>
 					<p class="description"><?php _e( 'Cache the specified pages even if they don\'t have tailing slash.', 'w3-total-cache' ); ?></p>

--- a/pub/js/options-validator.js
+++ b/pub/js/options-validator.js
@@ -1,0 +1,22 @@
+jQuery(document).ready(function() {
+	jQuery('textarea[w3tc-data-validator="regexps"]').change(function() {
+		var v = jQuery(this).val();
+		var items = v.split("\n");
+
+		for (var n = 0; n < items.length; n++) {
+			var regexp = items[n].trim();
+			if (regexp.length > 0) {
+				try {
+					new RegExp(regexp);
+				} catch(e) {
+					var error = 'Contains invalid regexp ' + regexp +', please fix';
+					console.log(error);
+					jQuery(this)[0].setCustomValidity(error);
+					return;
+				}
+			}
+		}
+
+		jQuery(this)[0].setCustomValidity('');
+	});
+});


### PR DESCRIPTION
If an attempt to save invalid regex value to config is made - fail to save it.

that will prevent warnings in "PgCache_ContentGrabber.php on line 946" on runtime