### PR TITLE
Apply a filter on the minified content - w3tc_minify_css_content

### DIFF
--- a/lib/Minify/Minify.php
+++ b/lib/Minify/Minify.php
@@ -613,6 +613,9 @@ class Minify0_Minify {
         if ($type === self::TYPE_CSS && false !== strpos($content, '@import')) {
             $content = self::_handleCssImports($content);
         }
+        if ( $type === self::TYPE_CSS ) {
+            $content = apply_filters( 'w3tc_css_content', $content, null, null );
+        }
 
         // do any post-processing (esp. for editing build URIs)
         if (self::$_options['postprocessorRequire']) {

--- a/lib/Minify/Minify.php
+++ b/lib/Minify/Minify.php
@@ -614,7 +614,7 @@ class Minify0_Minify {
             $content = self::_handleCssImports($content);
         }
         if ( $type === self::TYPE_CSS ) {
-            $content = apply_filters( 'w3tc_css_content', $content, null, null );
+            $content = apply_filters( 'w3tc_minify_css_content', $content, null, null );
         }
 
         // do any post-processing (esp. for editing build URIs)


### PR DESCRIPTION
This enables  image optimizers such as ShortPixel Adaptive Images to dynamically replace the background-image URLs in the W3 Total Cache cached versions of the CSS file, eliminating the need for another level of caching.

Fixes https://github.com/W3EDGE/w3-total-cache/issues/146