### PR TITLE
Release 0.14.2

### DIFF
--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -163,6 +163,7 @@ class Generic_Plugin {
 		}
 
 		if ( isset( $GLOBALS['w3tc_blogmap_register_new_item'] ) ) {
+			echo "\ngeneric_plugin reset\n";
 			$do_redirect = Util_WpmuBlogmap::register_new_item( $this->_config );
 
 			// reset cache of blog_id

--- a/lib/Minify/Minify/HTML.php
+++ b/lib/Minify/Minify/HTML.php
@@ -157,10 +157,16 @@ class Minify_HTML {
 			,$this->_html);
 
 		// remove trailing slash from void elements
-		$this->_html = preg_replace(
+		$_html = preg_replace(
 			'~<(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)(([^\'">]|\"[^\"]*\"|\'[^\']*\'|)*?)\\s*[/]?>~i'
 			,'<$1$2>'
 			,$this->_html);
+
+		// Avoid PREG_JIT_STACKLIMIT_ERROR.  Thanks @ericek111 for https://github.com/W3EDGE/w3-total-cache/issues/190.
+		if ( preg_last_error() === PREG_NO_ERROR ) {
+			$this->_html = $_html;
+		}
+		unset( $_html );
 
 		// use newlines before 1st attribute in open tags (to limit line lengths)
 		$this->_html = preg_replace('/(<[a-z\\-]+)\\s+([^>]+>)/i', "$1\n$2", $this->_html);

--- a/lib/Minify/Minify/IgnoredCommentPreserver.php
+++ b/lib/Minify/Minify/IgnoredCommentPreserver.php
@@ -14,15 +14,15 @@ class Minify_IgnoredCommentPreserver {
     }
 
     public function search($html) {
-        $html = preg_replace_callback('/<!--[\\s\\S]*?-->/', 
-            array($this, '_callback'), 
+        $html = preg_replace_callback('/<!--[\\s\\S]*?-->/',
+            array($this, '_callback'),
             $html);
         return $html;
     }
 
     public function replace($html) {
-        $html = str_replace(array_keys($this->_placeholders), 
-            array_values($this->_placeholders), 
+        $html = str_replace(array_keys($this->_placeholders),
+            array_values($this->_placeholders),
             $html);
         return $html;
     }
@@ -39,7 +39,7 @@ class Minify_IgnoredCommentPreserver {
 
     protected function _isIgnoredComment(&$comment) {
         foreach ($this->_ignoredComments as $ignoredComment) {
-            if (stristr($comment, $ignoredComment) !== false) {
+            if ( ! empty( $ignoredComment ) && stristr($comment, $ignoredComment ) !== false) {
                 return true;
             }
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: boldgrid, fredericktownes, maxicusc, gidomanders, bwmarkle, harryj
 Tags: seo, cache, optimize, pagespeed, performance, caching, compression, maxcdn, nginx, varnish, redis, new relic, aws, amazon web services, s3, cloudfront, rackspace, cloudflare, azure, apache
 Requires at least: 3.2
 Tested up to: 5.4
-Stable tag: 0.14.1
+Stable tag: 0.14.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -276,9 +276,10 @@ Please reach out to all of these people and support their projects if you're so 
 == Changelog ==
 
 = 0.14.2 =
-* Fixed WP-CLI rediect issue in multisite.
-* Fix: Avoid PREG_JIT_STACKLIMIT_ERROR in minify.
-* Fix: Prevent empty needle PHP warning.
+* Fixed WP-CLI rediect issue in multisite
+* Fix: Avoid PREG_JIT_STACKLIMIT_ERROR in minify
+* Fix: Prevent empty needle PHP warning
+* Update: Allow to specify URIs with a query string in Additional Pages
 
 = 0.14.1 =
 * Fixed CSS minify URL rewrite logic that affected some lazy loading and CSS URL addresses using protocols

--- a/readme.txt
+++ b/readme.txt
@@ -275,6 +275,11 @@ Please reach out to all of these people and support their projects if you're so 
 
 == Changelog ==
 
+= 0.14.2 =
+* Fixed WP-CLI rediect issue in multisite.
+* Fix: Avoid PREG_JIT_STACKLIMIT_ERROR in minify.
+* Fix: Prevent empty needle PHP warning.
+
 = 0.14.1 =
 * Fixed CSS minify URL rewrite logic that affected some lazy loading and CSS URL addresses using protocols
 

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -5,7 +5,7 @@ if ( !defined( 'ABSPATH' ) ) {
 }
 
 define( 'W3TC', true );
-define( 'W3TC_VERSION', '0.14.2-rc.1' );
+define( 'W3TC_VERSION', '0.14.2' );
 define( 'W3TC_POWERED_BY', 'W3 Total Cache' );
 define( 'W3TC_EMAIL', 'w3tc@w3-edge.com' );
 define( 'W3TC_TEXT_DOMAIN', 'w3-total-cache' );

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -5,7 +5,7 @@ if ( !defined( 'ABSPATH' ) ) {
 }
 
 define( 'W3TC', true );
-define( 'W3TC_VERSION', '0.14.1' );
+define( 'W3TC_VERSION', '0.14.2-rc.1' );
 define( 'W3TC_POWERED_BY', 'W3 Total Cache' );
 define( 'W3TC_EMAIL', 'w3tc@w3-edge.com' );
 define( 'W3TC_TEXT_DOMAIN', 'w3-total-cache' );

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: W3 Total Cache
 Description: The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
-Version: 0.14.2-rc.1
+Version: 0.14.2
 Plugin URI: https://www.boldgrid.com/totalcache/
 Author: BoldGrid
 Author URI: https://www.boldgrid.com/

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: W3 Total Cache
 Description: The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
-Version: 0.14.1
+Version: 0.14.2-rc.1
 Plugin URI: https://www.boldgrid.com/totalcache/
 Author: BoldGrid
 Author URI: https://www.boldgrid.com/


### PR DESCRIPTION
- Avoid PREG_JIT_STACKLIMIT_ERROR. Fixes #190
- Prevent warning on an empty needle. Fixes #203
- Allow to specify URIs with a query string in _Additional Pages_
  - _Performance->Page Cache->Additional Pages_ parameter wasnt processing
  - URIs with querystring correctly and didn't purge such pages when _Cache URIs with querystring_ option enabled
- Do not issue w3tc-repeat redirect when cli command executed.  Fixes #182
  - Attempt to switch config is made instead.
  - It may not work well for all possible cases since wp is partially initialized, but works for many
