### PR TITLE
update to pagespeed api v5, show webvitals metrics, fixes #192

### DIFF
--- a/PageSpeed_Api.php
+++ b/PageSpeed_Api.php
@@ -4,7 +4,7 @@ namespace W3TC;
 /**
  * Google Page Speed API
  */
-define( 'W3TC_PAGESPEED_API_URL', 'https://www.googleapis.com/pagespeedonline/v1/runPagespeed' );
+define( 'W3TC_PAGESPEED_API_URL', 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed' );
 
 /**
  * class PageSpeed_Api
@@ -14,34 +14,78 @@ class PageSpeed_Api {
 	 * API Key
 	 */
 	private $key = '';
-
 	/**
 	 * Referrer for key restricting
 	 */
 	private $key_restrict_referrer = '';
 
-	/**
-	 * PHP5-style constructor
-	 */
+
+
 	function __construct( $api_key, $api_ref ) {
 		$this->key = $api_key;
 		$this->key_restrict_referrer = $api_ref;
 	}
 
-	/**
-	 * Analyze URL
-	 */
-	function analyze( $url ) {
-		$json = $this->_request( $url );
-		if ( !$json )
-			return null;
 
-		$results = $this->_parse( $json );
-		if ( $results )
-			$this->_sort( $results );
 
-		return $results;
+	public function analyze( $url ) {
+		return array(
+			'mobile' => $this->analyze_strategy( $url, 'mobile' ),
+			'desktop' => $this->analyze_strategy( $url, 'desktop' ),
+			'test_url' => Util_Environment::url_format(
+				'https://developers.google.com/speed/pagespeed/insights/',
+				array( 'url' => $url ) )
+		);
 	}
+
+
+
+	public function analyze_strategy( $url, $strategy ) {
+		$json = $this->_request( array(
+				'url' => $url,
+				'category' => 'performance',
+				'strategy' => $strategy
+			) );
+
+		if ( !$json ) {
+			return null;
+		}
+
+		$data = array();
+		try {
+			$data = json_decode( $json, true );
+		} catch ( \Exception $e ) {
+		}
+
+		return array(
+			'score' => $this->v( $data, array( 'lighthouseResult', 'categories', 'performance', 'score' ) ) * 100,
+			'metrics' => $this->v( $data, array( 'loadingExperience', 'metrics' ) )
+		);
+	}
+
+
+
+	public function get_page_score( $url ) {
+		$json = $this->_request( array(
+				'url' => $url,
+				'category' => 'performance',
+				'strategy' => 'desktop'
+			) );
+
+		if ( !$json ) {
+			return null;
+		}
+
+		$data = array();
+		try {
+			$data = json_decode( $json, true );
+		} catch ( \Exception $e ) {
+		}
+
+		return $this->v( $data, array( 'lighthouseResult', 'categories', 'performance', 'score' ) );
+	}
+
+
 
 	/**
 	 * Make API request
@@ -49,11 +93,11 @@ class PageSpeed_Api {
 	 * @param string  $url
 	 * @return string
 	 */
-	function _request( $url ) {
-		$request_url = Util_Environment::url_format( W3TC_PAGESPEED_API_URL, array(
-				'url' => $url,
-				'key' => $this->key,
-			) );
+	function _request( $query ) {
+		$request_url = Util_Environment::url_format( W3TC_PAGESPEED_API_URL,
+			array_merge( $query, array(
+				'key' => $this->key
+			) ) );
 
 		$response = Util_Http::get( $request_url, array(
 				'timeout' => 120,
@@ -67,216 +111,18 @@ class PageSpeed_Api {
 		return false;
 	}
 
-	/**
-	 * Parse response
-	 *
-	 * @param string  $json
-	 * @return array|bool
-	 */
-	function _parse( $json ) {
-		$data = json_decode( $json );
-		$results = false;
 
-		if ( isset( $data->formattedResults ) ) {
-			$results = array(
-				'url' => $data->id,
-				'code' => $data->responseCode,
-				'title' => $data->title,
-				'score' => $data->score,
-				'rules' => array()
-			);
 
-			foreach ( (array) $data->formattedResults->ruleResults as $i => $rule_result ) {
-				$results['rules'][$i] = array(
-					'name' => $rule_result->localizedRuleName,
-					'impact' => $rule_result->ruleImpact,
-					'priority' => $this->_get_priority( $rule_result->ruleImpact ),
-					'resolution' => $this->_get_resolution( $rule_result->localizedRuleName ),
-					'blocks' => array()
-				);
-
-				if ( isset( $rule_result->urlBlocks ) ) {
-					foreach ( (array) $rule_result->urlBlocks as $j => $url_block ) {
-						$args = isset( $url_block->header->args ) ? $url_block->header->args : array();
-						$results['rules'][$i]['blocks'][$j] = array(
-							'header' => $this->_format_string( $url_block->header->format, $args ),
-							'urls' => array()
-						);
-
-						if ( isset( $url_block->urls ) ) {
-							foreach ( (array) $url_block->urls as $k => $url ) {
-								$args = isset( $url->result->args ) ? $url->result->args : array();
-								$results['rules'][$i]['blocks'][$j]['urls'][$k] = array(
-									'result' => $this->_format_string( $url->result->format, $args )
-								);
-							}
-						}
-					}
-				}
-			}
+	function v( $data, $elements ) {
+		if ( empty( $elements ) ) {
+			return $data;
 		}
 
-		return $results;
-	}
-
-	/**
-	 * Returns rule priority by impact
-	 *
-	 * @param float   $impact
-	 * @return string
-	 */
-	function _get_priority( $impact ) {
-		if ( $impact < 3 ) {
-			$priority = 'low';
-		} elseif ( $impact >= 3 && $impact <= 10 ) {
-			$priority = 'medium';
-		} else {
-			$priority = 'high';
+		$key = array_shift( $elements );
+		if ( !isset( $data[$key] ) ) {
+			return null;
 		}
 
-		return $priority;
-	}
-
-	/**
-	 * Returns resolution
-	 *
-	 * @param string  $code
-	 * @return array
-	 */
-	function _get_resolution( $code ) {
-		switch ( $code ) {
-		case 'MinifyHTML':
-			return array(
-				'header' => 'Enable HTML Minify',
-				'tab' => 'minify'
-			);
-
-		case 'MinifyJavaScript':
-		case 'DeferParsingJavaScript':
-			return array(
-				'header' => 'Enable JavaScript Minify',
-				'tab' => 'minify'
-			);
-
-		case 'MinifyCss':
-		case 'PutCssInTheDocumentHead':
-			return array(
-				'header' => 'Enable CSS Minify',
-				'tab' => 'minify'
-			);
-
-		case 'AvoidCssImport':
-			return array(
-				'header' => 'Enable CSS Minify and @import processing',
-				'tab' => 'minify'
-			);
-
-		case 'OptimizeTheOrderOfStylesAndScripts':
-			return array(
-				'header' => 'Enable JavaScript and CSS Minify',
-				'tab' => 'minify'
-			);
-
-		case 'PreferAsyncResources':
-			return array(
-				'header' => 'Switch to non-blocking JavaScript embedding',
-				'tab' => 'minify'
-			);
-
-		case 'RemoveQueryStringsFromStaticResources':
-			return array(
-				'header' => 'Disable the "Prevent caching of objects after settings change" feature',
-				'tab' => 'browsercache'
-			);
-
-		case 'LeverageBrowserCaching':
-			return array(
-				'header' => 'Enable the expires header on the Browser Cache Settings tab',
-				'tab' => 'browsercache'
-			);
-
-		case 'SpecifyACacheValidator':
-			return array(
-				'header' => 'Enable the ETag header on the Browser Cache Settings tab',
-				'tab' => 'browsercache'
-			);
-		}
-
-		return array();
-	}
-
-	private $_format_string_args = array();
-
-	/**
-	 * Formats string
-	 *
-	 * @param string  $format
-	 * @param array   $args
-	 * @return mixed
-	 */
-	function _format_string( $format, $args ) {
-		$result = $format;
-		if ( !empty( $args ) ) {
-			$this->_format_string_args = $args;
-
-			$result = preg_replace_callback( '~\$([0-9]+)~', array(
-					$this,
-					'_format_string_callback'
-				), $format );
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Format string callback
-	 *
-	 * @param array   $matches
-	 * @return string
-	 */
-	function _format_string_callback( $matches ) {
-		$index = (int) $matches[1] - 1;
-
-		if ( isset( $this->_format_string_args[$index]->value ) ) {
-			switch ( $this->_format_string_args[$index]->type ) {
-			case 'URL':
-				return sprintf( '<a href="%s">%s</a>', $this->_format_string_args[$index]->value, $this->_format_string_args[$index]->value );
-
-			default:
-				return $this->_format_string_args[$index]->value;
-			}
-		}
-
-		return $matches[0];
-	}
-
-	/**
-	 * Sort results
-	 *
-	 * @param array   $results
-	 * @return void
-	 */
-	function _sort( &$results ) {
-		if ( isset( $results['rules'] ) ) {
-			usort( $results['rules'], array(
-					$this,
-					'_sort_cmp'
-				) );
-		}
-	}
-
-	/**
-	 * Compare function
-	 *
-	 * @param array   $rule_result1
-	 * @param array   $rule_result2
-	 * @return int
-	 */
-	function _sort_cmp( &$rule_result1, &$rule_result2 ) {
-		if ( $rule_result1['impact'] == $rule_result2['impact'] ) {
-			return 0;
-		}
-
-		return ( $rule_result1['impact'] > $rule_result2['impact'] ) ? -1 : 1;
+		return $this->v( $data[$key], $elements );
 	}
 }

--- a/PageSpeed_Widget_View.css
+++ b/PageSpeed_Widget_View.css
@@ -2,69 +2,59 @@
     position: absolute;
 }
 
-.w3tc-widget-ps-rules {
-    margin: 1em 0;
-    background: #fff url(pub/img/ps_bar.gif) repeat-y;
+.w3tcps_scores {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
-.w3tc-widget-ps-rules a {
-    color: #00f;
-    text-decoration: none;
+.w3tcps_scores p {
+	padding: 0 10px;
 }
 
-.w3tc-widget-ps-rules li,
-.w3tc-widget-ps-rules p {
-    margin: 0;
+.w3tcps_scores section {
+	font-size: 30px;
+	font-weight: bold;
 }
 
-.w3tc-widget-ps-rule {
-    line-height: 20px;
-    clear: left;
+.w3tcps_metric {
+	margin-top: 10px;
+	margin-bottom: 5px;
 }
 
-.w3tc-widget-ps-rule p {
-    margin-left: 40px;
-    line-height: 20px;
-    height: 20px;
-    overflow: hidden;
+.w3tcps_barline {
+	display: flex;
+    font-size: 14px;
+	margin-bottom: 2px;
 }
 
-.w3tc-widget-ps-icon {
-    width: 31px;
-    height: 20px;
-    position: relative;
-    float: left;
+.w3tcps_barline div {
+	text-align: left;
+	padding-left: 10px;
+	min-width: 38px;
+	position: relative;
 }
 
-.w3tc-widget-ps-icon div {
-    display: block;
-    background: url(pub/img/ps_scores.png);
-    width: 14px;
-    height: 14px;
-    position: relative;
-    top: 3px;
-    left: 8px;
+.w3tcps_barfast {
+	background-color: #0cc66b;
+	color: #fff;
 }
 
-.w3tc-widget-ps-priority-high .w3tc-widget-ps-icon div {
-    background-position: 0;
+.w3tcps_baraverage {
+	background-color: #ffa400;
+	color: #000;
 }
 
-.w3tc-widget-ps-priority-medium .w3tc-widget-ps-icon div {
-    background-position: -14px;
+.w3tcps_barslow {
+	background-color: #ff4e42;
+	color: #fff;
 }
 
-.w3tc-widget-ps-priority-low .w3tc-widget-ps-icon div {
-    background-position: -28px;
+.w3tcps_buttons {
+	display: flex;
+	justify-content: center;
 }
 
-.w3tc-widget-ps-expand {
-    float: left;
-    width: 30px;
-    height: 20px;
-    text-align: center;
-}
-
-.w3tc-widget-ps-expand a {
-    color: #66d;
+.w3tcps_buttons .button {
+	margin: 5px;
 }

--- a/PageSpeed_Widget_View.js
+++ b/PageSpeed_Widget_View.js
@@ -1,43 +1,36 @@
 jQuery(document).ready(function($) {
-    function w3tcps_load(nocache) {
-        $('.w3tcps_loading').removeClass('w3tc_hidden');
-        $('.w3tcps_content').addClass('w3tc_hidden');
-        $('.w3tcps_error').addClass('w3tc_none');
+	function w3tcps_load(nocache) {
+		$('.w3tcps_loading').removeClass('w3tc_hidden');
+		$('.w3tcps_content').addClass('w3tc_hidden');
+		$('.w3tcps_error').addClass('w3tc_none');
 
-        $.getJSON(ajaxurl + '?action=w3tc_ajax&_wpnonce=' + w3tc_nonce + 
-            '&w3tc_action=pagespeed_widgetdata' + (nocache ? '&cache=no' : ''),
-            function(data) {
-                $('.w3tcps_loading').addClass('w3tc_hidden');
+		$.getJSON(ajaxurl + '?action=w3tc_ajax&_wpnonce=' + w3tc_nonce +
+			'&w3tc_action=pagespeed_widgetdata' + (nocache ? '&cache=no' : ''),
+			function(data) {
+				$('.w3tcps_loading').addClass('w3tc_hidden');
 
-                if (data.error) {
-                    $('.w3tcps_error').removeClass('w3tc_none');
-                    return;
-                }
+				if (data.error) {
+					$('.w3tcps_error').removeClass('w3tc_none');
+					return;
+				}
 
-                jQuery('.w3tcps_score').html(data.score);
-                jQuery('.w3tcps_list').html(data.details);
-                
-                $('.w3tcps_content').removeClass('w3tc_hidden');
-            }
-        ).fail(function() {
-            $('.w3tcps_error').removeClass('w3tc_none');
-            $('.w3tcps_content').addClass('w3tc_hidden');
-            $('.w3tcps_loading').addClass('w3tc_hidden');
-        });
-    }
+				jQuery('.w3tcps_content').html(data['.w3tcps_content']);
+				$('.w3tcps_content').removeClass('w3tc_hidden');
+			}
+		).fail(function() {
+			$('.w3tcps_error').removeClass('w3tc_none');
+			$('.w3tcps_content').addClass('w3tc_hidden');
+			$('.w3tcps_loading').addClass('w3tc_hidden');
+		});
+	}
 
 
 
-    jQuery('.w3tc-widget-ps-view-all').click(function() {
-        window.open('admin.php?page=w3tc_dashboard&w3tc_test_pagespeed_results&_wpnonce=' + jQuery(this).metadata().nonce, 'pagespeed_results', 'width=800,height=600,status=no,toolbar=no,menubar=no,scrollbars=yes');
-        return false;
-    });
-
-    jQuery('.w3tc-widget-ps-refresh').click(function() {
-        w3tcps_load(true);
-    });
+	jQuery('.w3tcps_content').on('click', '.w3tcps_refresh', function() {
+		w3tcps_load(true);
+	});
 
 
 
-    w3tcps_load();
+	w3tcps_load();
 });

--- a/PageSpeed_Widget_View.php
+++ b/PageSpeed_Widget_View.php
@@ -7,42 +7,52 @@ if ( !defined( 'W3TC' ) )
 ?>
 <div class="w3tcps_loading w3tc_loading w3tc_hidden">Loading...</div>
 <div class="w3tcps_error w3tc_none">
-    <p>Unable to fetch Page Speed results.</p>
-    <p>
-        <input class="button w3tc-widget-ps-refresh" type="button" value="Refresh Analysis" />
-    </p>
+	<p>Unable to fetch Page Speed results.</p>
+	<p>
+		<input class="button w3tc-widget-ps-refresh" type="button" value="Refresh Analysis" />
+	</p>
 </div>
 
 <div class="w3tcps_content w3tc_hidden">
-    <h4>Page Speed Score: <span class="w3tcps_score"></span></h4>
+	<div class="w3tcps_scores">
+		<section title="Mobile">0</section>
+		<p>|</p>
+		<section title="Desktop">4</section>
+	</div>
 
-    <div class="w3tcps_list">
-        <ul class="w3tc-widget-ps-rules">
-            <li>
-                <div class="w3tc-widget-ps-icon"><div></div></div>
-                <p>.</p>
-            </li>
-            <li>
-                <div class="w3tc-widget-ps-icon"><div></div></div>
-                <p>.</p>
-            </li>
-            <li>
-                <div class="w3tc-widget-ps-icon"><div></div></div>
-                <p>.</p>
-            </li>
-            <li>
-                <div class="w3tc-widget-ps-icon"><div></div></div>
-                <p>.</p>
-            </li>
-            <li>
-                <div class="w3tc-widget-ps-icon"><div></div></div>
-                <p>.</p>
-            </li>
-        </ul>
-    </div>
+	<div>
+		<div class="w3tcps_metric">V</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_metric">V</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_metric">V</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_metric">V</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+		<div class="w3tcps_barline">
+			<div class="w3tcps_barfast">0%</div>
+		</div>
+	</div>
 
-    <p>
-        <input class="button w3tc-widget-ps-refresh" type="button" value="Refresh analysis" />
-        <input class="button w3tc-widget-ps-view-all {nonce: '<?php echo wp_create_nonce( 'w3tc' ); ?>'}" type="button" value="View all results" />
-    </p>
+	<div class="w3tcps_buttons">
+		<input class="button w3tcps_refresh" type="button" value="Refresh analysis" />
+		<a href="#" class="button">View all results</a>
+	</div>
 </div>

--- a/PageSpeed_Widget_View_FromApi.php
+++ b/PageSpeed_Widget_View_FromApi.php
@@ -1,0 +1,62 @@
+<?php
+namespace W3TC;
+
+if ( !defined( 'W3TC' ) )
+	die();
+
+$r = $api_response;
+$rm = $api_response['mobile'];
+$rd = $api_response['desktop'];
+
+
+
+function w3tcps_barline($metric) {
+	if ( !is_array( $metric['distributions'] ) ||
+			count( $metric['distributions'] ) < 3 ) {
+		return;
+	}
+
+	$v1 = round((float)$metric['distributions'][0]['proportion'] * 100);
+	$v2 = round((float)$metric['distributions'][1]['proportion'] * 100);
+	$v3 = round((float)$metric['distributions'][2]['proportion'] * 100);
+
+	?>
+	<div class="w3tcps_barline">
+		<div class="w3tcps_barfast" style="flex-grow: <?php echo esc_html($v1) ?>"><?php echo esc_html($v1) ?>%</div>
+		<div class="w3tcps_baraverage" style="flex-grow: <?php echo esc_html($v2) ?>"><?php echo esc_html($v2) ?>%</div>
+		<div class="w3tcps_barslow" style="flex-grow: <?php echo esc_html($v3) ?>;"><?php echo esc_html($v3) ?>%</div>
+	</div>
+	<?php
+}
+
+
+
+function w3tcps_bar($r, $metric, $name) {
+	if ( !isset( $r['desktop']['metrics'][$metric] ) ) {
+		return;
+	}
+
+	echo '<div class="w3tcps_metric">' . esc_html( $name ) . '</div>';
+	w3tcps_barline( $r['mobile']['metrics'][$metric]);
+	w3tcps_barline( $r['desktop']['metrics'][$metric]);
+}
+
+
+
+?>
+<div class="w3tcps_scores">
+	<section title="Mobile"><?php echo esc_html( $rm['score'] ) ?></section>
+	<p>|</p>
+	<section title="Desktop"><?php echo esc_html( $rd['score'] ) ?></section>
+</div>
+
+<div>
+	<?php w3tcps_bar($r, 'LARGEST_CONTENTFUL_PAINT_MS', 'Largest Contentful Paint') ?>
+	<?php w3tcps_bar($r, 'FIRST_CONTENTFUL_PAINT_MS', 'First Contentful Paint') ?>
+	<?php w3tcps_bar($r, 'FIRST_INPUT_DELAY_MS', 'First Input Delay') ?>
+	<?php w3tcps_bar($r, 'CUMULATIVE_LAYOUT_SHIFT_SCORE', 'Cumulative Layout Shift') ?>
+</div>
+<div class="w3tcps_buttons">
+	<input class="button w3tcps_refresh" type="button" value="Refresh analysis" />
+	<a href="<?php echo esc_html( $r['test_url'] ) ?>" target="_blank" class="button">View all results</a>
+</div>


### PR DESCRIPTION
Google Page Speed dashboard widget was using v1 api version which is obsolete now.
Showing more relevant webvitals metrics in a dashboard now.