### PR TITLE
activation wasnt handing environment changes. fixes #251

### DIFF
--- a/Root_AdminActivation.php
+++ b/Root_AdminActivation.php
@@ -37,6 +37,7 @@ class Root_AdminActivation {
 			$e = Dispatcher::component( 'Root_Environment' );
 
 			$config = Dispatcher::config();
+			$e->fix_in_wpadmin( $config, true );
 			$e->fix_on_event( $config, 'activate' );
 
 			// try to save config file if needed, optional thing so exceptions


### PR DESCRIPTION
activation was supposed to be wpadmin-only operation and didnt call full
environment update since wp-admin request was doing it right after ui
plugin activation.

but its possible to activate via wp-cli now too.