### PR TITLE
Check for Aws before loading functions.  Fixes #247

### DIFF
--- a/lib/Aws/aws-autoloader.php
+++ b/lib/Aws/aws-autoloader.php
@@ -1159,7 +1159,10 @@ spl_autoload_register(function ($class) use ($mapping) {
     }
 }, true);
 
-require __DIR__ . '/Aws/functions.php';
+if ( ! function_exists( 'Aws\parse_ini_file' ) ) {
+	require __DIR__ . '/Aws/functions.php';
+}
+
 require __DIR__ . '/GuzzleHttp/functions_include.php';
 require __DIR__ . '/GuzzleHttp/Psr7/functions_include.php';
 require __DIR__ . '/GuzzleHttp/Promise/functions_include.php';


### PR DESCRIPTION
The reporter (Jesse) and I both tested this fix.
To replicate:

1. Install a plugin that loads the Aws library, such as BackWPup.
1. Add a new BackWPup job saving to Amazon S3 and include your AWS client id and secret.
1. In the W3TC `General Settings`, select `Amazon Simple Storage Service (S3)` and save the settings.
1. Navigate to the W3TC `CDN` settings page.
1.  You should not see a critical error message.  Feel free to configure and test AWS credentials.
