### PR TITLE
Always set HSTS header if configured.  Fixes #257

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -376,7 +376,7 @@ class BrowserCache_Environment {
 
 			if ( $config->get_boolean( 'browsercache.hsts' ) ) {
 				$dir = $config->get_string( 'browsercache.security.hsts.directive' );
-				$rules .= "    Header set Strict-Transport-Security \"max-age=$lifetime" . ( strpos( $dir,"inc" ) ? "; includeSubDomains" : "" ) . ( strpos( $dir, "pre" ) ? "; preload" : "" ) . "\"\n";
+				$rules .= "    Header always set Strict-Transport-Security \"max-age=$lifetime" . ( strpos( $dir,"inc" ) ? "; includeSubDomains" : "" ) . ( strpos( $dir, "pre" ) ? "; preload" : "" ) . "\"\n";
 			}
 
 			if ( $config->get_boolean( 'browsercache.security.xfo' ) ) {


### PR DESCRIPTION
Apache should always set HSTS headers, not only for 2xx HTTP codes.

The `Strict-Transport-Security` header in Apache should always be sent if configured.  Without `always` in the `Header` line redirects and errors will not include the header.
