### PR TITLE
WP55 QA

### DIFF
--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -45,6 +45,10 @@ class PgCache_Plugin {
 		add_filter( 'cron_schedules',
 			array( $this, 'cron_schedules' ) );
 
+		add_action( 'w3tc_config_save',
+			array( $this, 'w3tc_config_save' ),
+			10, 1 );
+
 		$o = Dispatcher::component( 'PgCache_ContentGrabber' );
 
 		add_filter( 'w3tc_footer_comment',
@@ -380,4 +384,14 @@ class PgCache_Plugin {
 
 		return $header;
 	}
+
+
+
+	public function w3tc_config_save( $config ) {
+		// frontend activity
+		if ( $config->get_boolean( 'pgcache.cache.feed' ) ) {
+			$config->set( 'pgcache.cache.nginx_handle_xml', true );
+		}
+	}
+
 }

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -512,12 +512,22 @@ class Util_Environment {
 		$home_path = ABSPATH;
 		if ( ! empty( $home ) && 0 !== strcasecmp( $home, $siteurl ) ) {
 			$wp_path_rel_to_home = str_ireplace( $home, '', $siteurl ); /* $siteurl - $home */
-			$pos = strripos( str_replace( '\\', '/', $_SERVER['SCRIPT_FILENAME'] ), trailingslashit( $wp_path_rel_to_home ) );
 			// fix of get_home_path, used when index.php is moved outside of
 			// wp folder.
+			$pos = strripos(
+				str_replace( '\\', '/', $_SERVER['SCRIPT_FILENAME'] ),
+				trailingslashit( $wp_path_rel_to_home ) );
 			if ( $pos !== false ) {
 				$home_path = substr( $_SERVER['SCRIPT_FILENAME'], 0, $pos );
 				$home_path = trailingslashit( $home_path );
+			} else if ( defined( 'WP_CLI' ) ) {
+				$pos = strripos(
+					str_replace( '\\', '/', ABSPATH ),
+					trailingslashit( $wp_path_rel_to_home ) );
+				if ( $pos !== false ) {
+					$home_path = substr( ABSPATH, 0, $pos );
+					$home_path = trailingslashit( $home_path );
+				}
 			}
 		}
 

--- a/qa/env/100-generate-envs
+++ b/qa/env/100-generate-envs
@@ -160,13 +160,7 @@ def generate_box_descriptors(image_name)
 
 	box_descriptors = multiply(box_descriptors, {
 		# 4.0
-		'wp431' => {
-			'WP_VERSION' => '4.3.1',
-			'_except_name_contains' => [
-				'php70', 'php71', 'php73',   # many stuff gone deprecated
-				'varnish'
-			]
-		},
+		# 4.3.1
 		# 4.5.3
 		# 4.6
 		# 4.7
@@ -202,6 +196,12 @@ def generate_box_descriptors(image_name)
 			'WP_VERSION' => '5.3',
 			'_except_name_contains' => [
 				'php55'   # wp5.3 requires php>=5.6
+			]
+		},
+		'wp55' => {
+			'WP_VERSION' => '5.5-RC1',
+			'_except_name_contains' => [
+				'php55'   # wp5.5 requires php>=5.6
 			]
 		}
 	}, image_name)

--- a/qa/env/scripts/http-server-error-log-read.sh
+++ b/qa/env/scripts/http-server-error-log-read.sh
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
 
 cat $W3D_HTTP_SERVER_ERROR_LOG_FILENAME |\
-  grep -v "class-simplepie.php" |\
-  grep -v "in /var/www/wp-sandbox/.*/post.php"  |\
-  grep -v "File does not exist:.*404.jpg" |\
-  grep -v "File does not exist: /var/www/wp-sandbox/.*b2$" |\
-  grep -v "open().*404.jpg.*failed.*No such file or directory" |\
-  grep -v "wp-includes/pluggable.php on line 216" |\
-  pcregrep -v -M "Call to undefined function esc_attr[()]+ in .*PgCache_ContentGrabber.php.*eval(\n|.)*?request" |\
-  grep -v "Call to undefined function esc_attr() in .*PgCache_ContentGrabber.php.*eval()" |\
-  grep -v "script '/var/www/wp-sandbox/wp-signup.php' not found or unable to stat" |\
-  grep -v "wp-admin/includes/dashboard.php on line 1227" |\
-  grep -v "WP_Community_Events::maybe_log_events_response" |\
-  grep -v "wp-includes/Requests/Transport/cURL.php:422" |\
-  grep -v "Undefined index: recommended_version in /var/www/.*/class-wp-site-health.php" |\
-  grep -v "Undefined index: no_update in /var/www/.*/update.php"
-
-if [ -f "${W3D_WP_CONTENT_PATH}debug.log" ]; then
-	cat "${W3D_WP_CONTENT_PATH}debug.log" |\
 	grep -v "class-simplepie.php" |\
 	grep -v "in /var/www/wp-sandbox/.*/post.php"  |\
 	grep -v "File does not exist:.*404.jpg" |\
@@ -30,8 +13,25 @@ if [ -f "${W3D_WP_CONTENT_PATH}debug.log" ]; then
 	grep -v "wp-admin/includes/dashboard.php on line 1227" |\
 	grep -v "WP_Community_Events::maybe_log_events_response" |\
 	grep -v "wp-includes/Requests/Transport/cURL.php:422" |\
-    grep -v "Undefined index: recommended_version in /var/www/.*/class-wp-site-health.php" |\
-    grep -v "Undefined index: no_update in /var/www/.*/update.php"
+	grep -v "Undefined index: recommended_version in /var/www/.*/class-wp-site-health.php" |\
+	grep -v "Undefined index: no_update in /var/www/.*/update.php"
+
+if [ -f "${W3D_WP_CONTENT_PATH}debug.log" ]; then
+	cat "${W3D_WP_CONTENT_PATH}debug.log" |\
+		grep -v "class-simplepie.php" |\
+		grep -v "in /var/www/wp-sandbox/.*/post.php"  |\
+		grep -v "File does not exist:.*404.jpg" |\
+		grep -v "File does not exist: /var/www/wp-sandbox/.*b2$" |\
+		grep -v "open().*404.jpg.*failed.*No such file or directory" |\
+		grep -v "wp-includes/pluggable.php on line 216" |\
+		pcregrep -v -M "Call to undefined function esc_attr[()]+ in .*PgCache_ContentGrabber.php.*eval(\n|.)*?request" |\
+		grep -v "Call to undefined function esc_attr() in .*PgCache_ContentGrabber.php.*eval()" |\
+		grep -v "script '/var/www/wp-sandbox/wp-signup.php' not found or unable to stat" |\
+		grep -v "wp-admin/includes/dashboard.php on line 1227" |\
+		grep -v "WP_Community_Events::maybe_log_events_response" |\
+		grep -v "wp-includes/Requests/Transport/cURL.php:422" |\
+		grep -v "Undefined index: recommended_version in /var/www/.*/class-wp-site-health.php" |\
+		grep -v "Undefined index: no_update in /var/www/.*/update.php"
 fi
 # esc_attr in eval - pagecache/late-init test
 # in php7.0-fpm call stack is printed so should be eliminated

--- a/qa/env/scripts/http-server-error-log-read.sh
+++ b/qa/env/scripts/http-server-error-log-read.sh
@@ -12,7 +12,9 @@ cat $W3D_HTTP_SERVER_ERROR_LOG_FILENAME |\
   grep -v "script '/var/www/wp-sandbox/wp-signup.php' not found or unable to stat" |\
   grep -v "wp-admin/includes/dashboard.php on line 1227" |\
   grep -v "WP_Community_Events::maybe_log_events_response" |\
-  grep -v "wp-includes/Requests/Transport/cURL.php:422"
+  grep -v "wp-includes/Requests/Transport/cURL.php:422" |\
+  grep -v "Undefined index: recommended_version in /var/www/.*/class-wp-site-health.php" |\
+  grep -v "Undefined index: no_update in /var/www/.*/update.php"
 
 if [ -f "${W3D_WP_CONTENT_PATH}debug.log" ]; then
 	cat "${W3D_WP_CONTENT_PATH}debug.log" |\
@@ -27,7 +29,9 @@ if [ -f "${W3D_WP_CONTENT_PATH}debug.log" ]; then
 	grep -v "script '/var/www/wp-sandbox/wp-signup.php' not found or unable to stat" |\
 	grep -v "wp-admin/includes/dashboard.php on line 1227" |\
 	grep -v "WP_Community_Events::maybe_log_events_response" |\
-	grep -v "wp-includes/Requests/Transport/cURL.php:422"
+	grep -v "wp-includes/Requests/Transport/cURL.php:422" |\
+    grep -v "Undefined index: recommended_version in /var/www/.*/class-wp-site-health.php" |\
+    grep -v "Undefined index: no_update in /var/www/.*/update.php"
 fi
 # esc_attr in eval - pagecache/late-init test
 # in php7.0-fpm call stack is printed so should be eliminated

--- a/qa/env/scripts/init-box/760-wordpress-pathmoved.sh
+++ b/qa/env/scripts/init-box/760-wordpress-pathmoved.sh
@@ -15,6 +15,7 @@ sed -i "2idefine( \"WP_CONTENT_DIR\", rtrim( \"$W3D_WP_CONTENT_PATH\", \"/\" ) )
 
 cd /var/www/wp-sandbox${W3D_WP_HOME_URI}
 sed -i "s%dirname( __FILE__ )%\"${W3D_WP_PATH}\"%" index.php
+sed -i "s%__DIR__%\"${W3D_WP_PATH}\"%" index.php
 
 if [ "$W3D_HTTP_SERVER" = 'apache' ]; then
 	mv ${W3D_WP_PATH}.htaccess /var/www/wp-sandbox/

--- a/qa/lib/wp.js
+++ b/qa/lib/wp.js
@@ -172,20 +172,47 @@ async function postCreateWP5(pPage, data) {
 		await pPage.click('button[aria-label="Show more tools & options"]');
 	} else {
 		await pPage.click('button[aria-label="More tools & options"]');
+
+		try {
+			await pPage.waitForSelector('button[aria-label="More tools & options"][aria-expanded="true"]', {
+				timeout: 3000
+			});
+		} catch (e) {
+			log.error('click failed, repeating');
+
+			await pPage.click('button[aria-label="More tools & options"]');
+
+			await pPage.waitForSelector('button[aria-label="More tools & options"][aria-expanded="true"]', {
+				timeout: 5000
+			});
+		}
 	}
 
 	if (parseFloat(env.wpVersion) < 5.2) {
 		await pPage.click('button[aria-label="Code Editor"]');
 	} else {
+		if (parseFloat(env.wpVersion) < 5.5) {
+			await pPage.waitForSelector('.components-popover__content', {
+				visible: true
+			});
+		} else {
+			await pPage.waitForSelector('.components-dropdown-menu__popover', {
+				visible: true
+			});
+		}
+
 		let clicked = await pPage.evaluate(() => {
 			let elements = document.getElementsByClassName('components-menu-item__button');
 			for (let element of elements) {
-				if (element.innerHTML.indexOf('Code Editor') >= 0) {
+				if (element.innerHTML.toLowerCase().indexOf('code editor') >= 0) {
 					element.click();
 					return 'clicked';
 				}
 			}
+
+			return 'code editor button notfound';
 		});
+
 		expect(clicked).equals('clicked');
 	}
 
@@ -270,14 +297,33 @@ async function postCreateWP5(pPage, data) {
 	await pPage.click('.editor-post-publish-button');
 	log.log('create page - waiting for published state');
 	try {
-		await pPage.waitForSelector('.editor-post-publish-panel__header-published', {timeout: 5000});
+		if (parseFloat(env.wpVersion) < 5.5) {
+			await pPage.waitForSelector('.editor-post-publish-panel__header-published', {
+				timeout: 5000
+			});
+		} else {
+			await pPage.waitForSelector('.post-publish-panel__postpublish-header', {
+				timeout: 5000
+			});
+		}
+
 	} catch (e) {
 		log.error('failed');
 
 		log.log('click2');
 		await pPage.click('.editor-post-publish-button');
 		log.log('create page - waiting for published state2');
-		await pPage.waitForSelector('.editor-post-publish-panel__header-published', {timeout: 5000});
+
+		if (parseFloat(env.wpVersion) < 5.5) {
+			await pPage.waitForSelector('.editor-post-publish-panel__header-published', {
+				timeout: 5000
+			});
+		} else {
+			await pPage.waitForSelector('.post-publish-panel__postpublish-header', {
+				timeout: 5000
+			});
+		}
+
 		log.log('now seems ok');
 	}
 
@@ -356,20 +402,47 @@ async function postUpdateWP5(pPage, data) {
 		await pPage.click('button[aria-label="Show more tools & options"]');
 	} else {
 		await pPage.click('button[aria-label="More tools & options"]');
+
+		try {
+			await pPage.waitForSelector('button[aria-label="More tools & options"][aria-expanded="true"]', {
+				timeout: 3000
+			});
+		} catch (e) {
+			log.error('click failed, repeating');
+
+			await pPage.click('button[aria-label="More tools & options"]');
+
+			await pPage.waitForSelector('button[aria-label="More tools & options"][aria-expanded="true"]', {
+				timeout: 5000
+			});
+		}
 	}
 
 	if (parseFloat(env.wpVersion) < 5.2) {
 		await pPage.click('button[aria-label="Code Editor"]');
 	} else {
+		if (parseFloat(env.wpVersion) < 5.5) {
+			await pPage.waitForSelector('.components-popover__content', {
+				visible: true
+			});
+		} else {
+			await pPage.waitForSelector('.components-dropdown-menu__popover', {
+				visible: true
+			});
+		}
+
 		let clicked = await pPage.evaluate(() => {
 			let elements = document.getElementsByClassName('components-menu-item__button');
 			for (let element of elements) {
-				if (element.innerHTML.indexOf('Code Editor') >= 0) {
+				if (element.innerHTML.toLowerCase().indexOf('code editor') >= 0) {
 					element.click();
 					return 'clicked';
 				}
 			}
+
+			return 'code editor button notfound';
 		});
+
 		expect(clicked).equals('clicked');
 	}
 

--- a/qa/tests/generic/referrer-groups-theme.js
+++ b/qa/tests/generic/referrer-groups-theme.js
@@ -18,8 +18,10 @@ else if (parseFloat(env.wpVersion) < 4.7)
 	otherTheme = 'twentyfourteen/twentyfourteen';
 else if (parseFloat(env.wpVersion) < 5.0)
 	otherTheme = 'twentyfifteen/twentyfifteen';
-else
+else if (parseFloat(env.wpVersion) < 5.5)
 	otherTheme = 'twentysixteen/twentysixteen';
+else
+	otherTheme = 'twentynineteen/twentynineteen';
 
 let pluginUrl = env.blogSiteUrl.replace(/(b2\.)?wp\.sandbox/i, 'for-tests.wp.sandbox') +
 	'referrer-groups.php?path=' + env.blogSiteUrl;
@@ -96,6 +98,9 @@ describe('', function() {
 				(e) => e.getAttribute('href'));
 		} else if (theme[0] == 'twentysixteen') {
 		 	css = await page.$eval('#twentysixteen-style-css',
+				(e) => e.getAttribute('href'));
+		} else if (theme[0] == 'twentynineteen') {
+			css = await page.$eval('#twentynineteen-style-css',
 				(e) => e.getAttribute('href'));
 		} else {
 			css = await page.$eval('link[type="text/css"]',

--- a/qa/tests/generic/user-agent-groups.js
+++ b/qa/tests/generic/user-agent-groups.js
@@ -18,8 +18,12 @@ else if (parseFloat(env.wpVersion) < 4.7)
 	otherTheme = 'twentyfourteen/twentyfourteen';
 else if (parseFloat(env.wpVersion) < 5.0)
 	otherTheme = 'twentyfifteen/twentyfifteen';
-else
+else if (parseFloat(env.wpVersion) < 5.0)
+	otherTheme = 'twentyfifteen/twentyfifteen';
+else if (parseFloat(env.wpVersion) < 5.5)
 	otherTheme = 'twentysixteen/twentysixteen';
+else
+	otherTheme = 'twentynineteen/twentynineteen';
 
 let pluginUrl = env.blogSiteUrl.replace(/(b2\.)?wp\.sandbox/, 'for-tests.wp.sandbox') +
 	'user-agent-groups.php?path=' + env.blogSiteUrl;
@@ -98,6 +102,9 @@ describe('', function() {
 				(e) => e.getAttribute('href'));
 		} else if (theme[0] == 'twentysixteen') {
 		 	css = await page.$eval('#twentysixteen-style-css',
+				(e) => e.getAttribute('href'));
+		} else if (theme[0] == 'twentynineteen') {
+			css = await page.$eval('#twentynineteen-style-css',
 				(e) => e.getAttribute('href'));
 		} else {
 			css = await page.$eval('link[type="text/css"]',

--- a/qa/tests/generic/user-signup-single.js
+++ b/qa/tests/generic/user-signup-single.js
@@ -125,6 +125,9 @@ describe('', function() {
 			expect(await page.content()).contains('Your password has been reset');
 		} else {
 			let m = mail.match(/visit the following address:\s*<(http[^>]+)>/m);
+			if (m == null) {
+				m = mail.match(/visit the following address:\s*(http[^\s]+)/m);
+			}
 			let followUrl = m[1];
 
 			log.log('found ' + followUrl);


### PR DESCRIPTION
Make tests passing with wp55.
Support basic WordPress environments with moved paths when operated via wp-cli - default WordPress code can't detects root path in this case what particularly causes generation of .htaccess rules in a wrong folder.