### PR TITLE
Fixed typo in activation file conflict exception message method name.

### DIFF
--- a/Util_Activation.php
+++ b/Util_Activation.php
@@ -54,7 +54,7 @@ class Util_Activation {
 		$reactivate_button = sprintf( '%1$sre-activate plugin', '<input type="button" value="' ) .
 			sprintf( '" onclick="top.location.href = \'%s\'" />', addslashes( $reactivate_url ) );
 
-		self::_error( sprintf( __( '%s<br />then %s.', 'w3-total-cache' ), $e->getMessage(), $reactivate_button ) );
+		self::_error( sprintf( __( '%s<br />then %s.', 'w3-total-cache' ), $e->getCombinedMessage(), $reactivate_button ) );
 	}
 
 	/**


### PR DESCRIPTION
The exception method name was incorrect in the call from the activation, which prevented the message from being printed in the admin notice.
To replicate the issue, delete W3TC, create a new file `wp-content/advanced-cache.php`, install and activate W3TC.  You will see an admin notice with a fatal error message and a reactivate button, but it does not say what happened or how to fix it.
![image](https://user-images.githubusercontent.com/11447263/94183588-a5392780-fe70-11ea-9a6a-32faca619c00.png)

After the fix, the message and fix button is displayed.
![image](https://user-images.githubusercontent.com/11447263/94183636-b8e48e00-fe70-11ea-9a28-fe98cf25551f.png)
