### PR TITLE
Add option to minify only for both JS and CSS in auto mode

### DIFF
--- a/ConfigCompiler.php
+++ b/ConfigCompiler.php
@@ -247,6 +247,19 @@ class ConfigCompiler {
 		}
 
 		//
+		// changes in 0.15.2
+		//
+		if ( version_compare( $file_data['version'], '0.15.2', '<' ) ) {
+			if ( isset( $file_data['minify.js.combine.header'] ) && $file_data['minify.js.combine.header'] ) {
+				$file_data['minify.js.method'] = 'combine';
+			}
+
+			if ( isset( $file_data['minify.css.combine'] ) && $file_data['minify.css.combine'] ) {
+				$file_data['minify.css.method'] = 'combine';
+			}
+		}
+
+		//
 		// changes in 0.13
 		//
 		if ( version_compare( $file_data['version'], '0.12.0', '<=' ) ) {

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -848,10 +848,6 @@ $keys = array(
 		'type' => 'string',
 		'default' => 'both'
 	),
-	'minify.css.combine' => array(
-		'type' => 'boolean',
-		'default' => false
-	),
 	'minify.css.http2push' => array(
 		'type' => 'boolean',
 		'default' => false

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -836,10 +836,6 @@ $keys = array(
 			'mfunc'
 		)
 	),
-	'minify.css.combine' => array(
-		'type' => 'boolean',
-		'default' => false
-	),
 	'minify.css.enable' => array(
 		'type' => 'boolean',
 		'default' => true
@@ -847,6 +843,14 @@ $keys = array(
 	'minify.css.engine' => array(
 		'type' => 'string',
 		'default' => 'css'
+	),
+	'minify.css.method' => array(
+		'type' => 'string',
+		'default' => 'both'
+	),
+	'minify.css.combine' => array(
+		'type' => 'boolean',
+		'default' => false
 	),
 	'minify.css.http2push' => array(
 		'type' => 'boolean',
@@ -883,6 +887,10 @@ $keys = array(
 	'minify.js.engine' => array(
 		'type' => 'string',
 		'default' => 'js'
+	),
+	'minify.js.method' => array(
+		'type' => 'string',
+		'default' => 'both'
 	),
 	'minify.js.combine.header' => array(
 		'type' => 'boolean',

--- a/Minify_AutoCss.php
+++ b/Minify_AutoCss.php
@@ -253,7 +253,7 @@ class Minify_AutoCss {
 			$this->embed_pos = $tag_pos;
 		$this->files_to_minify[] = $file;
 
-		if ( $this->config->get_boolean( 'minify.js.method' ) == 'minify' )
+		if ( $this->config->get_string( 'minify.css.method' ) == 'minify' )
 			$this->flush_collected( '' );
 	}
 

--- a/Minify_AutoCss.php
+++ b/Minify_AutoCss.php
@@ -252,6 +252,9 @@ class Minify_AutoCss {
 		if ( count( $this->files_to_minify ) <= 0 )
 			$this->embed_pos = $tag_pos;
 		$this->files_to_minify[] = $file;
+
+		if ( $this->config->get_boolean( 'minify.js.method' ) == 'minify' )
+			$this->flush_collected( '' );
 	}
 
 	/**

--- a/Minify_AutoJs.php
+++ b/Minify_AutoJs.php
@@ -267,6 +267,9 @@ class Minify_AutoJs {
 		}
 
 		$this->files_to_minify[$sync_type]['files'][] = $file;
+
+		if ( $this->config->get_string( 'minify.css.method' ) == 'minify' )
+			$this->flush_collected( $sync_type, '' );
 	}
 
 	/**

--- a/Minify_AutoJs.php
+++ b/Minify_AutoJs.php
@@ -268,7 +268,7 @@ class Minify_AutoJs {
 
 		$this->files_to_minify[$sync_type]['files'][] = $file;
 
-		if ( $this->config->get_string( 'minify.css.method' ) == 'minify' )
+		if ( $this->config->get_string( 'minify.js.method' ) == 'minify' )
 			$this->flush_collected( $sync_type, '' );
 	}
 

--- a/Minify_ConfigLabels.php
+++ b/Minify_ConfigLabels.php
@@ -27,7 +27,6 @@ class Minify_ConfigLabels {
 				'minify.js.footer.embed_type' => __( 'Before <span class="html-tag">&lt;/body&gt;</span>', 'w3-total-cache' ),
 				'minify.js.combine.footer' => __( 'Combine only', 'w3-total-cache' ),
 				'minify.css.enable' => __( 'Enable', 'w3-total-cache' ),
-				'minify.css.combine' => __( 'Combine only', 'w3-total-cache' ),
 				'minify.css.imports' => __( '@import handling:', 'w3-total-cache' ),
 				'minify.lifetime' => __( 'Update external files every:', 'w3-total-cache' ),
 				'minify.file.gc' => __( 'Garbage collection interval:', 'w3-total-cache' ),

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -177,7 +177,8 @@ class Minify_MinifiedFileRequestHandler {
 			$minifier_type = 'application/x-javascript';
 
 			switch ( true ) {
-			case ( ( $hash || $location == 'include' ) && ( $this->_config->get_boolean( 'minify.js.combine.header' || $this->_config->get_string( 'minify.js.method' ) == 'combine' ) ) ):
+			case ( $hash && $this->_config->get_string( 'minify.js.method' ) == 'combine' ):
+			case ( $location == 'include' && $this->_config->get_boolean( 'minify.js.combine.header' ) ):
 			case ( $location == 'include-body' && $this->_config->get_boolean( 'minify.js.combine.body' ) ):
 			case ( $location == 'include-footer' && $this->_config->get_boolean( 'minify.js.combine.footer' ) ):
 				$engine = 'combinejs';
@@ -195,7 +196,7 @@ class Minify_MinifiedFileRequestHandler {
 		} elseif ( $type == 'css' ) {
 			$minifier_type = 'text/css';
 
-			if ( ( $hash || $location == 'include' ) && ( $this->_config->get_boolean( 'minify.css.combine' ) || $this->_config->get_string( 'minify.css.method' ) == 'combine' ) ) {
+			if ( ( $hash || $location == 'include' ) && $this->_config->get_string( 'minify.css.method' ) == 'combine' ) {
 				$engine = 'combinecss';
 			} else {
 				$engine = $this->_config->get_string( 'minify.css.engine' );
@@ -857,15 +858,27 @@ class Minify_MinifiedFileRequestHandler {
 			'minify.symlinks',
 		);
 
+		$auto = $this->_config->get_boolean( 'minify.auto' );
+
 		if ( $type == 'js' ) {
 			$engine = $this->_config->get_string( 'minify.js.engine' );
+
+			if ( $auto ) {
+				$keys[] = 'minify.js.method';
+			} else {
+				array_merge(
+					$keys,
+					array(
+						'minify.js.combine.header',
+						'minify.js.combine.body',
+						'minify.js.combine.footer',
+					)
+				);
+			}
 
 			switch ( $engine ) {
 			case 'js':
 				$keys = array_merge( $keys, array(
-						'minify.js.combine.header',
-						'minify.js.combine.body',
-						'minify.js.combine.footer',
 						'minify.js.strip.comments',
 						'minify.js.strip.crlf',
 					) );
@@ -889,11 +902,11 @@ class Minify_MinifiedFileRequestHandler {
 			}
 		} elseif ( $type == 'css' ) {
 			$engine = $this->_config->get_string( 'minify.css.engine' );
+			$keys[] = 'minify.css.method';
 
 			switch ( $engine ) {
 			case 'css':
 				$keys = array_merge( $keys, array(
-						'minify.css.combine',
 						'minify.css.strip.comments',
 						'minify.css.strip.crlf',
 						'minify.css.imports',

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -177,7 +177,7 @@ class Minify_MinifiedFileRequestHandler {
 			$minifier_type = 'application/x-javascript';
 
 			switch ( true ) {
-			case ( ( $hash || $location == 'include' ) && $this->_config->get_boolean( 'minify.js.combine.header' ) ):
+			case ( ( $hash || $location == 'include' ) && ( $this->_config->get_boolean( 'minify.js.combine.header' || $this->_config->get_string( 'minify.js.method' ) == 'combine' ) ) ):
 			case ( $location == 'include-body' && $this->_config->get_boolean( 'minify.js.combine.body' ) ):
 			case ( $location == 'include-footer' && $this->_config->get_boolean( 'minify.js.combine.footer' ) ):
 				$engine = 'combinejs';
@@ -195,7 +195,7 @@ class Minify_MinifiedFileRequestHandler {
 		} elseif ( $type == 'css' ) {
 			$minifier_type = 'text/css';
 
-			if ( ( $hash || $location == 'include' ) && $this->_config->get_boolean( 'minify.css.combine' ) ) {
+			if ( ( $hash || $location == 'include' ) && ( $this->_config->get_boolean( 'minify.css.combine' ) || $this->_config->get_string( 'minify.css.method' ) == 'combine' ) ) {
 				$engine = 'combinecss';
 			} else {
 				$engine = $this->_config->get_string( 'minify.css.engine' );

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -858,12 +858,10 @@ class Minify_MinifiedFileRequestHandler {
 			'minify.symlinks',
 		);
 
-		$auto = $this->_config->get_boolean( 'minify.auto' );
-
 		if ( $type == 'js' ) {
 			$engine = $this->_config->get_string( 'minify.js.engine' );
 
-			if ( $auto ) {
+			if ( $this->_config->get_boolean( 'minify.auto' ) ) {
 				$keys[] = 'minify.js.method';
 			} else {
 				array_merge(

--- a/Util_Admin.php
+++ b/Util_Admin.php
@@ -381,7 +381,6 @@ class Util_Admin {
 				$minify_dependencies = array_merge( $minify_dependencies, array(
 						'minify.css.engine',
 						'minify.css.method',
-						'minify.css.combine',
 						'minify.css.strip.comments',
 						'minify.css.strip.crlf',
 						'minify.css.imports',

--- a/Util_Admin.php
+++ b/Util_Admin.php
@@ -380,6 +380,7 @@ class Util_Admin {
 			if ( $new_config->get_boolean( 'minify.css.enable' ) && ( $new_config->get_boolean( 'minify.auto' ) || count( $new_config->get_array( 'minify.css.groups' ) ) ) ) {
 				$minify_dependencies = array_merge( $minify_dependencies, array(
 						'minify.css.engine',
+						'minify.css.method',
 						'minify.css.combine',
 						'minify.css.strip.comments',
 						'minify.css.strip.crlf',
@@ -411,6 +412,7 @@ class Util_Admin {
 			if ( $new_config->get_boolean( 'minify.js.enable' ) && ( $new_config->get_boolean( 'minify.auto' ) || count( $new_config->get_array( 'minify.js.groups' ) ) ) ) {
 				$minify_dependencies = array_merge( $minify_dependencies, array(
 						'minify.js.engine',
+						'minify.js.method',
 						'minify.js.combine.header',
 						'minify.js.combine.body',
 						'minify.js.combine.footer',

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -208,7 +208,13 @@ if ( file_exists( $html_engine_file2 ) ) {
 					<?php if ( $auto ): ?>
 						<p>
 							<?php $this->radio( 'minify.js.combine.header', false, false, 'js_' ) ?> <?php _e( 'Minify', 'w3-total-cache' ); ?> </label> <?php $this->radio( 'minify.js.combine.header', true, false, 'js_' ) ?> <?php Util_Ui::e_config_label( 'minify.js.combine.header' ) ?></label>
+							<select id="minify__js__method" name="minify__js__method" class="js_enabled">
+								<option value="both" <?php selected( 'both' , $this->_config->get_string( 'minify.js.method' ) ) ?>><?php _e( 'Combine & Minify', 'w3-total-cache' ); ?></option>
+								<option value="minify" <?php selected( 'minify' , $this->_config->get_string( 'minify.js.method' ) ) ?>><?php _e( 'Minify only', 'w3-total-cache' ); ?></option>
+								<option value="combine" <?php selected( 'combine' , $this->_config->get_string( 'minify.js.method' ) ) ?>><?php _e( 'Combine only', 'w3-total-cache' ); ?></option>
+							</select>
 						</p>
+						<br />
 					<?php endif; ?>
 
 					<?php
@@ -332,7 +338,15 @@ Util_Ui::config_item( array(
 			<tr>
 				<th><?php _e( '<acronym title="Cascading Style Sheet">CSS</acronym> minify settings:', 'w3-total-cache' ); ?></th>
 				<td>
-					<?php $this->checkbox( 'minify.css.enable' ) ?> <?php Util_Ui::e_config_label( 'minify.css.enable' ) ?></label><br />
+					<p>
+						<?php $this->checkbox( 'minify.css.enable' ) ?> <?php Util_Ui::e_config_label( 'minify.css.enable' ) ?></label><br />
+						<select id="minify__css__method" name="minify__css__method" class="css_enabled">
+							<option value="both" <?php selected( 'both' , $this->_config->get_string( 'minify.css.method' ) ) ?>><?php _e( 'Combine & Minify', 'w3-total-cache' ); ?></option>
+							<option value="minify" <?php selected( 'minify' , $this->_config->get_string( 'minify.css.method' ) ) ?>><?php _e( 'Minify only', 'w3-total-cache' ); ?></option>
+							<option value="combine" <?php selected( 'combine' , $this->_config->get_string( 'minify.css.method' ) ) ?>><?php _e( 'Combine only', 'w3-total-cache' ); ?></option>
+						</select>
+					</p>
+					<br />
 					<?php $this->checkbox( 'minify.css.combine', false, 'css_' ) ?> <?php Util_Ui::e_config_label( 'minify.css.combine' ) ?></label><br />
 					<?php
 $css_engine_file = '';

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -144,10 +144,10 @@ if ( file_exists( $html_engine_file2 ) ) {
 			<?php
 			if ( $auto ):
 				Util_Ui::config_item( array(
-				'key' => 'minify.js.method',
-				'label' => 'Minify method:',
-				'control' => 'selectbox',
-				'selectbox_values' => array(
+					'key' => 'minify.js.method',
+					'label' => 'Minify method:',
+					'control' => 'selectbox',
+					'selectbox_values' => array(
 						'both' => array(
 							'label' => __( 'Combine & Minify', 'w3-total-cache' )
 						),
@@ -161,7 +161,6 @@ if ( file_exists( $html_engine_file2 ) ) {
 				) );
 			endif; 
 			?>
-			<!-- <?php $this->radio( 'minify.js.combine.header', false, false, 'js_' ) ?> <?php _e( 'Minify', 'w3-total-cache' ); ?> </label> <?php $this->radio( 'minify.js.combine.header', true, false, 'js_' ) ?> <?php Util_Ui::e_config_label( 'minify.js.combine.header' ) ?></label> -->
 			<tr>
 				<th><?php _e( 'Minify engine settings:', 'w3-total-cache' ); ?></th>
 				<td>
@@ -362,10 +361,10 @@ Util_Ui::config_item( array(
 			?>
 			<?php
 			Util_Ui::config_item( array(
-			'key' => 'minify.css.method',
-			'label' => 'Minify method:',
-			'control' => 'selectbox',
-			'selectbox_values' => array(
+				'key' => 'minify.css.method',
+				'label' => 'Minify method:',
+				'control' => 'selectbox',
+				'selectbox_values' => array(
 					'both' => array(
 						'label' => __( 'Combine & Minify', 'w3-total-cache' )
 					),
@@ -378,7 +377,6 @@ Util_Ui::config_item( array(
 				)
 			) );
 			?>
-			<!-- <?php $this->checkbox( 'minify.css.combine', false, 'css_' ) ?> <?php Util_Ui::e_config_label( 'minify.css.combine' ) ?></label><br /> -->
 			<tr>
 				<th><?php _e( 'Minify engine settings:', 'w3-total-cache' ); ?></th>
 				<td>

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -133,10 +133,38 @@ if ( file_exists( $html_engine_file2 ) ) {
 
 		<?php Util_Ui::postbox_header( __( '<acronym title="JavaScript">JS</acronym>', 'w3-total-cache' ), '', 'js' ); ?>
 		<table class="form-table">
+			<?php
+			Util_Ui::config_item( array(
+				'key' => 'minify.js.enable',
+				'label' => '<acronym title="JavaScript">JS</acronym> minify settings:',
+				'control' => 'checkbox',
+				'checkbox_label' => __( 'Enable', 'w3-total-cache' )
+			) );
+			?>
+			<?php
+			if ( $auto ):
+				Util_Ui::config_item( array(
+				'key' => 'minify.js.method',
+				'label' => 'Minify method:',
+				'control' => 'selectbox',
+				'selectbox_values' => array(
+						'both' => array(
+							'label' => __( 'Combine & Minify', 'w3-total-cache' )
+						),
+						'minify' => array(
+							'label' => __( 'Minify only', 'w3-total-cache' )
+						),
+						'combine' => array(
+							'label' => __( 'Combine only', 'w3-total-cache' )
+						)
+					)
+				) );
+			endif; 
+			?>
+			<!-- <?php $this->radio( 'minify.js.combine.header', false, false, 'js_' ) ?> <?php _e( 'Minify', 'w3-total-cache' ); ?> </label> <?php $this->radio( 'minify.js.combine.header', true, false, 'js_' ) ?> <?php Util_Ui::e_config_label( 'minify.js.combine.header' ) ?></label> -->
 			<tr>
-				<th><?php _e( '<acronym title="JavaScript">JS</acronym> minify settings:', 'w3-total-cache' ); ?></th>
+				<th><?php _e( 'Minify engine settings:', 'w3-total-cache' ); ?></th>
 				<td>
-					<?php $this->checkbox( 'minify.js.enable' ) ?> <?php Util_Ui::e_config_label( 'minify.js.enable' ) ?></label><br />
 					<fieldset><legend><?php _e( 'Operations in areas:', 'w3-total-cache' ); ?></legend>
 						<table id="minify_table">
 							<tr>
@@ -205,17 +233,6 @@ if ( file_exists( $html_engine_file2 ) ) {
 							<?php endif; ?>
 						</table>
 					</fieldset>
-					<?php if ( $auto ): ?>
-						<p>
-							<?php $this->radio( 'minify.js.combine.header', false, false, 'js_' ) ?> <?php _e( 'Minify', 'w3-total-cache' ); ?> </label> <?php $this->radio( 'minify.js.combine.header', true, false, 'js_' ) ?> <?php Util_Ui::e_config_label( 'minify.js.combine.header' ) ?></label>
-							<select id="minify__js__method" name="minify__js__method" class="js_enabled">
-								<option value="both" <?php selected( 'both' , $this->_config->get_string( 'minify.js.method' ) ) ?>><?php _e( 'Combine & Minify', 'w3-total-cache' ); ?></option>
-								<option value="minify" <?php selected( 'minify' , $this->_config->get_string( 'minify.js.method' ) ) ?>><?php _e( 'Minify only', 'w3-total-cache' ); ?></option>
-								<option value="combine" <?php selected( 'combine' , $this->_config->get_string( 'minify.js.method' ) ) ?>><?php _e( 'Combine only', 'w3-total-cache' ); ?></option>
-							</select>
-						</p>
-						<br />
-					<?php endif; ?>
 
 					<?php
 $js_engine_file = '';
@@ -335,19 +352,36 @@ Util_Ui::config_item( array(
 
 		<?php Util_Ui::postbox_header( __( '<acronym title="Cascading Style Sheet">CSS</acronym>', 'w3-total-cache' ), '', 'css' ); ?>
 		<table class="form-table">
+			<?php
+			Util_Ui::config_item( array(
+				'key' => 'minify.css.enable',
+				'label' => '<acronym title="Cascading Style Sheet">CSS</acronym> minify settings:',
+				'control' => 'checkbox',
+				'checkbox_label' => __( 'Enable', 'w3-total-cache' )
+			) );
+			?>
+			<?php
+			Util_Ui::config_item( array(
+			'key' => 'minify.css.method',
+			'label' => 'Minify method:',
+			'control' => 'selectbox',
+			'selectbox_values' => array(
+					'both' => array(
+						'label' => __( 'Combine & Minify', 'w3-total-cache' )
+					),
+					'minify' => array(
+						'label' => __( 'Minify only', 'w3-total-cache' )
+					),
+					'combine' => array(
+						'label' => __( 'Combine only', 'w3-total-cache' )
+					)
+				)
+			) );
+			?>
+			<!-- <?php $this->checkbox( 'minify.css.combine', false, 'css_' ) ?> <?php Util_Ui::e_config_label( 'minify.css.combine' ) ?></label><br /> -->
 			<tr>
-				<th><?php _e( '<acronym title="Cascading Style Sheet">CSS</acronym> minify settings:', 'w3-total-cache' ); ?></th>
+				<th><?php _e( 'Minify engine settings:', 'w3-total-cache' ); ?></th>
 				<td>
-					<p>
-						<?php $this->checkbox( 'minify.css.enable' ) ?> <?php Util_Ui::e_config_label( 'minify.css.enable' ) ?></label><br />
-						<select id="minify__css__method" name="minify__css__method" class="css_enabled">
-							<option value="both" <?php selected( 'both' , $this->_config->get_string( 'minify.css.method' ) ) ?>><?php _e( 'Combine & Minify', 'w3-total-cache' ); ?></option>
-							<option value="minify" <?php selected( 'minify' , $this->_config->get_string( 'minify.css.method' ) ) ?>><?php _e( 'Minify only', 'w3-total-cache' ); ?></option>
-							<option value="combine" <?php selected( 'combine' , $this->_config->get_string( 'minify.css.method' ) ) ?>><?php _e( 'Combine only', 'w3-total-cache' ); ?></option>
-						</select>
-					</p>
-					<br />
-					<?php $this->checkbox( 'minify.css.combine', false, 'css_' ) ?> <?php Util_Ui::e_config_label( 'minify.css.combine' ) ?></label><br />
 					<?php
 $css_engine_file = '';
 


### PR DESCRIPTION
Hi there,

I've added the option to minify CSS and JS without combining which fixes #170.

However, is there a way to map the values from the current config key to the new config key after a plugin update? 
For example if the current value of `minify.css.combine == true`, I would like to set the intital value of `minify.css.method = 'combine'` else `minify.css.method = 'both'`. And at the same time how can we deprecate or remove `minify.css.combine`.
Can the authors (or other contributors) provide some input on this.

**Benefits**

Fixes #170, benefits described in the issue.

**Future PRs**

- Allow ignoring .min.js and .min.css when minify only.