### PR TITLE
Move get_response_headers to Util_Http

### DIFF
--- a/Util_Content.php
+++ b/Util_Content.php
@@ -26,6 +26,29 @@ class Util_Content {
 			stripos( $content, '<html' ) === 0 ||
 			stripos( $content, '<!DOCTYPE' ) === 0;
 	}
+	
+	/**
+	 * Checks HTTP headers sent (or ready to be sent) by the server and returns true
+	 * if the content-type is SGML-y (text/html, text/xml, RSS feeds and similar)
+	 *
+	 * @return bool
+	 */
+	static public function is_html_xml_content_type() {
+		$content_type = '';
+		
+		$headers = Util_Http::get_response_headers();
+		if ( isset ( $headers['kv']['content-type'] ) ) {
+			$content_type = $headers['kv']['content-type'];
+		}
+		
+		$sgml_types = array(
+			'text/html', 'text/xml', 'text/xsl',
+			'application/xhtml+xml', 'application/rss+xml',
+			'application/atom+xml', 'application/rdf+xml'
+		);
+		
+		return in_array( $content_type, $sgml_types );
+	}
 
 	static private function _is_html_prepare( $content ) {
 		if ( strlen( $content ) > 1000 ) {

--- a/Util_Http.php
+++ b/Util_Http.php
@@ -103,4 +103,47 @@ class Util_Http {
 
 		return $upload_info;
 	}
+	
+	/**
+	 * Returns array of response headers
+	 *
+	 * @return array
+	 */
+	static public function get_response_headers() {
+		$headers_kv = array();
+		$headers_plain = array();
+		
+		$headers_list = null;
+		// headers_list() will return an empty array for CLI environments, grab them like this for PHPUnit testing env.
+		if (php_sapi_name() === 'cli' && function_exists( 'xdebug_get_headers' ) ) {
+			$headers_list = xdebug_get_headers();
+		} else if ( function_exists( 'headers_list' ) ) {
+			$headers_list = headers_list();
+		}
+		
+		if ( $headers_list ) {
+			foreach ( $headers_list as $header ) {
+				$pos = strpos( $header, ':' );
+				if ( $pos ) {
+					$header_name = trim( substr( $header, 0, $pos ) );
+					$header_value = trim( substr( $header, $pos + 1 ) );
+					$header_name = strtolower( $header_name );
+				} else {
+					$header_name = $header;
+					$header_value = '';
+				}
+				$headers_kv[$header_name] = $header_value;
+				$headers_plain[] = array(
+					'name' => $header_name,
+					'value' => $header_value
+				);
+			}
+		}
+		
+		return array(
+			'kv' => $headers_kv,
+			'plain' => $headers_plain
+		);
+	}
+	
 }


### PR DESCRIPTION
There was some redundant code regarding HTTP headers. Now it's more dumb-proof (handles testing environments with XDebug) and generalized.

This commit is a result of a little brain fart, but I figured it'd be beneficial to make a PR anyway.