### PR TITLE
removal of spaces in calc was breaking css, fixes #287

### DIFF
--- a/lib/Minify/Minify/CSS/Compressor.php
+++ b/lib/Minify/Minify/CSS/Compressor.php
@@ -118,12 +118,12 @@ class Minify_CSS_Compressor {
         $css = preg_replace_callback('/
                 (?:              # non-capture
                     \\s*
-                    [^~>+,\\s]+  # selector part
+                    [^{}~>+,\\s]+  # selector part
                     \\s*
                     [,>+~]       # combinators
                 )+
                 \\s*
-                [^~>+,\\s]+      # selector part
+                [^{}~>+,\\s]+      # selector part
                 {                # open declaration block
             /x'
             ,array($this, '_selectorsCB'), $css);


### PR DESCRIPTION
regexp whose intend is to remove spaces in css selectors like
".my-class > img" was selecting beyond selector definition and catching
will the last css element.
So spaces in calc() in all except last css declaration were trimmed out

img {
    height: calc(1px + 1px);
}
a {
}