### PR TITLE
Dont remove quotes around meta tags, fixes #187

### DIFF
--- a/Cache_Memcache.php
+++ b/Cache_Memcache.php
@@ -220,6 +220,7 @@ class Cache_Memcache extends Cache_Base {
 		// expiration has to be as long as possible since
 		// all cache data expires when key version expires
 		@$this->_memcache->set( $this->_get_key_version_key( $group ), $v, false, 0 );
+		$this->_key_version[$group] = $v;
 	}
 
 	/**
@@ -231,9 +232,12 @@ class Cache_Memcache extends Cache_Base {
 	 */
 	private function _increment_key_version( $group = '' ) {
 		$r = @$this->_memcache->increment( $this->_get_key_version_key( $group ), 1 );
-		if ( ! $r ) {
+
+		if ( $r ) {
+			$this->_key_version[$group] = $r;
+		} else {
 			// it doesn't initialize the key if it doesn't exist.
-			$this->_set_key_version( 0, $group );
+			$this->_set_key_version( 2, $group );
 		}
 	}
 

--- a/Cache_Memcached.php
+++ b/Cache_Memcached.php
@@ -283,6 +283,7 @@ class Cache_Memcached extends Cache_Base {
 		// expiration has to be as long as possible since
 		// all cache data expires when key version expires
 		@$this->_memcache->set( $this->_get_key_version_key( $group ), $v, 0 );
+		$this->_key_version[$group] = $v;
 	}
 
 	/**
@@ -294,9 +295,12 @@ class Cache_Memcached extends Cache_Base {
 	 */
 	private function _increment_key_version( $group = '' ) {
 		$r = @$this->_memcache->increment( $this->_get_key_version_key( $group ), 1 );
-		if ( ! $r ) {
+
+		if ( $r ) {
+			$this->_key_version[$group] = $r;
+		} else {
 			// it doesn't initialize the key if it doesn't exist.
-			$this->_set_key_version( 0, $group );
+			$this->_set_key_version( 2, $group );
 		}
 	}
 


### PR DESCRIPTION
meta tags are not parsed by browsers directly, but by apps, which seems do it violating W3C and fail to parse valid HTML without quotes.

WhatsApp is noted multiple times before acting bad in this case.

Google is not confirmed yet, even opposite - we have a lot of examples where meta tags don't have quotes and they are parsed well by google. There should be something else / more specific than just a quote for meta description tag.

It looks relevant trade-off in such situation to exclude meta tag from quotes removal optimization.
Negative effect is that websites with a lot of meta-tags, i.e. those implementing microdata and doing that meta-option way may have a lot of such. It's not so popular way at the moment.