### PR TITLE
Do not use Redis SETEX when expire=0

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -62,11 +62,13 @@ class Cache_Redis extends Cache_Base {
 
 		$storage_key = $this->get_item_key( $key );
 		$accessor = $this->_get_accessor( $storage_key );
-		if ( is_null( $accessor ) )
+		if ( is_null( $accessor ) ) {
 			return false;
+		}
 
-		if ( $expire === 0 )
+		if ( ! $expire ) {
 			return $accessor->set( $storage_key, serialize( $value ) );
+		}
 
 		return $accessor->setex( $storage_key, $expire, serialize( $value ) );
 	}

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -65,6 +65,9 @@ class Cache_Redis extends Cache_Base {
 		if ( is_null( $accessor ) )
 			return false;
 
+		if ( $expire === 0 )
+			return $accessor->set( $storage_key, serialize( $value ) );
+
 		return $accessor->setex( $storage_key, $expire, serialize( $value ) );
 	}
 


### PR DESCRIPTION
In redis 6 (and possibly earlier), calling SETEX with an expiry of 0 seconds is invalid.  When $expire is 0, call SET instead.