### PR TITLE
Allow cache in PHP-CLI/console and fix bugs when clearing cache from PHP-CLI/console

### DIFF
--- a/CdnEngine_Mirror_CloudFront.php
+++ b/CdnEngine_Mirror_CloudFront.php
@@ -49,7 +49,7 @@ class CdnEngine_Mirror_CloudFront extends CdnEngine_Mirror {
 	 * @return string
 	 */
 	function _get_origin() {
-		return Util_Environment::host_port();
+		return Util_Environment::host();
 	}
 
 	/**

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -154,7 +154,7 @@ class Generic_Plugin {
 		if ( is_multisite() && !is_network_admin() ) {
 			global $w3_current_blog_id, $current_blog;
 			if ( $w3_current_blog_id != $current_blog->blog_id && !isset( $GLOBALS['w3tc_blogmap_register_new_item'] ) ) {
-				$url = Util_Environment::host_port() . $_SERVER['REQUEST_URI'];
+				$url = Util_Environment::host() . $_SERVER['REQUEST_URI'];
 				$pos = strpos( $url, '?' );
 				if ( $pos !== false )
 					$url = substr( $url, 0, $pos );

--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -780,15 +780,6 @@ class ObjectCache_WpObjectCache_Regular {
 	 */
 	function _can_cache() {
 		/**
-		 * Don't cache in console mode
-		 */
-		if ( PHP_SAPI === 'cli' ) {
-			$this->cache_reject_reason = 'Console mode';
-
-			return false;
-		}
-
-		/**
 		 * Skip if disabled
 		 */
 		if ( !$this->_config->get_boolean( 'objectcache.enabled' ) ) {

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -122,7 +122,7 @@ class PgCache_ContentGrabber {
 		$this->_debug = $this->_config->get_boolean( 'pgcache.debug' );
 
 		$this->_request_url_fragments = array(
-			'host' => Util_Environment::host_port()
+			'host' => Util_Environment::host()
 		);
 
 		$this->_request_uri = $_SERVER['REQUEST_URI'];
@@ -884,7 +884,7 @@ class PgCache_ContentGrabber {
 						'cache_dir' =>
 							W3TC_CACHE_PAGE_ENHANCED_DIR .
 							DIRECTORY_SEPARATOR .
-							Util_Environment::host_port(),
+							Util_Environment::host(),
 						'flush_parent' => ( Util_Environment::blog_id() == 0 ),
 						'locking' => $this->_config->get_boolean( 'pgcache.file.locking' ),
 						'flush_timelimit' => $this->_config->get_integer( 'timelimit.cache_flush' )

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -189,7 +189,7 @@ class PgCache_Plugin {
 	}
 
 	public function redirect_on_foreign_domain() {
-		$request_host = Util_Environment::host();
+		$request_host = Util_Environment::request_host();
 		// host not known, potentially we are in console mode not http request
 		if ( empty( $request_host ) )
 			return;

--- a/Support_AdminActions.php
+++ b/Support_AdminActions.php
@@ -173,7 +173,6 @@ class Support_AdminActions {
 				'home_url_host' => Util_Environment::home_url_host(),
 				'home_url_uri' => Util_Environment::home_url_uri(),
 				'network_home_url_uri' => Util_Environment::network_home_url_uri(),
-				'host_port' => Util_Environment::host_port(),
 				'host' => Util_Environment::host(),
 				'wp_config_path' => Util_Environment::wp_config_path()
 			),

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -662,28 +662,22 @@ class Util_Environment {
 		return $uri;
 	}
 
-	/**
-	 * Returns server hostname with port
-	 *
-	 * @return string
-	 */
-	static public function host_port() {
-		static $host = null;
+	static public function host() {
+		$host_port = get_option( 'siteurl' );
 
-		if ( $host === null ) {
-			if ( !empty( $_SERVER['HTTP_HOST'] ) ) {
-				// HTTP_HOST sometimes is not set causing warning
-				$host = $_SERVER['HTTP_HOST'];
-			} else {
-				$host = '';
-			}
-		}
+		$pos = strpos( $host_port, ':' );
+		if ( $pos === false )
+			return $host_port;
 
-		return $host;
+		return substr( $host_port, 0, $pos );
 	}
 
-	static public function host() {
-		$host_port = Util_Environment::host_port();
+	static public function request_host() {
+		$host_port = $_SERVER['HTTP_HOST'];
+
+		if($host_port === null) {
+			return ''; 
+		}
 
 		$pos = strpos( $host_port, ':' );
 		if ( $pos === false )

--- a/inc/options/cdn/cf2.php
+++ b/inc/options/cdn/cf2.php
@@ -27,7 +27,7 @@ if ( !defined( 'W3TC' ) )
 <tr>
 	<th><?php _e( 'Origin:', 'w3-total-cache' ); ?></th>
 	<td>
-		<?php echo Util_Environment::host_port(); ?>
+		<?php echo Util_Environment::host(); ?>
 		<input id="cdn_create_container"
 					   <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> class="button {type: 'cf2', nonce: '<?php echo wp_create_nonce( 'w3tc' ); ?>'}" type="button" value="<?php _e( 'Create distribution', 'w3-total-cache' ); ?>" />
 		<span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>


### PR DESCRIPTION
1. Allow cache to store new values when in PHP-CLI/console environment.
In our use case we have a time consuming cron-evebt that regularily updates a value in the object cache. We only run cron events from wp-cli, not webrequests.

2. Use wordpress option value 'siteurl' instead of $_SERVER['HTTP_HOST'].
This is important because when running from PHP-CLI/console, the $_SERVER['HTTP_HOST'] value is empty.
Because $_SERVER['HTTP_HOST'] is empty, the cache keys for e.g memcached will be different from the keys from regular webrequests.
This commit will fix problems when attempting to flush cache values from PHP-CLI/console environment.