### PR TITLE
Allow cache in PHP-CLI/console. Add new optional config parameter 'ho…

### DIFF
--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -662,28 +662,33 @@ class Util_Environment {
 		return $uri;
 	}
 
-	/**
-	 * Returns server hostname with port
-	 *
-	 * @return string
-	 */
 	static public function host_port() {
-		static $host = null;
+		$config = Dispatcher::config();
+		$host_port = $config->get_string( 'host', $_SERVER['HTTP_HOST'] );
 
-		if ( $host === null ) {
-			if ( !empty( $_SERVER['HTTP_HOST'] ) ) {
-				// HTTP_HOST sometimes is not set causing warning
-				$host = $_SERVER['HTTP_HOST'];
-			} else {
-				$host = '';
-			}
+		if($host_port === null) {
+			$host_port = '';
 		}
 
-		return $host;
+		return $host_port;
 	}
 
 	static public function host() {
-		$host_port = Util_Environment::host_port();
+		$host_port = self::host_port(); 
+
+		$pos = strpos( $host_port, ':' );
+		if ( $pos === false )
+			return $host_port;
+
+		return substr( $host_port, 0, $pos );
+	}
+
+	static public function request_host() {
+		$host_port = $_SERVER['HTTP_HOST'];
+
+		if($host_port === null) {
+			return ''; 
+		}
 
 		$pos = strpos( $host_port, ':' );
 		if ( $pos === false )


### PR DESCRIPTION
Allow cache to store new values when in PHP-CLI/console environment.
In our use case we have a time consuming cron-evett that regularily updates a value in the object cache. We only run cron events from wp-cli, not webrequests.

I propose to add support for a new config option 'host', which will be optional.
Use w3-total-cache config value 'host' instead of $_SERVER['HTTP_HOST'], if it is present.
This is important because when running from PHP-CLI/console, the $_SERVER['HTTP_HOST'] value is empty, unless url is specified in the wp-cli command.
When $_SERVER['HTTP_HOST'] is empty, the cache keys for e.g memcached will be different from the keys from regular webrequests