### PR TITLE
Don't persist the 'comment' object cache group by default

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -316,7 +316,6 @@ $keys = array(
 	'objectcache.groups.nonpersistent' => array(
 		'type' => 'array',
 		'default' => array(
-			'comment',
 			'counts',
 			'plugins'
 		)


### PR DESCRIPTION
We should probably mirror WP core with this behavior. Their developers are confident enough to make the `comment` group persistent: https://github.com/WordPress/WordPress/commit/1f2635d52b34c2a3df967135a20c12f415299103