### PR TITLE
Add video/ogg support for browser chaging

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -106,6 +106,7 @@ class BrowserCache_Environment {
 		unset( $other_compression['mov|qt'] );
 		unset( $other_compression['mp3|m4a'] );
 		unset( $other_compression['mp4|m4v'] );
+		unset( $other_compression['ogv'] );
 		unset( $other_compression['mpeg|mpg|mpe'] );
 		unset( $other_compression['png'] );
 		unset( $other_compression['ra|ram'] );

--- a/inc/mime/other.php
+++ b/inc/mime/other.php
@@ -36,6 +36,7 @@ return array(
 	'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
 	'odt' => 'application/vnd.oasis.opendocument.text',
 	'ogg' => 'audio/ogg',
+	'ogv' => 'video/ogg',
 	'pdf' => 'application/pdf',
 	'png' => 'image/png',
 	'pot|pps|ppt|pptx' => 'application/vnd.ms-powerpoint',

--- a/ini/apache_conf/mod_expires.conf
+++ b/ini/apache_conf/mod_expires.conf
@@ -36,6 +36,7 @@ ExpiresByType audio/midi A31536000
 ExpiresByType video/quicktime A31536000
 ExpiresByType audio/mpeg A31536000
 ExpiresByType video/mp4 A31536000
+ExpiresByType video/ogg A31536000
 ExpiresByType video/mpeg A31536000
 ExpiresByType application/vnd.ms-project A31536000
 ExpiresByType application/x-font-otf A31536000

--- a/ini/apache_conf/mod_mime.conf
+++ b/ini/apache_conf/mod_mime.conf
@@ -32,6 +32,7 @@
   AddType video/quicktime .mov .qt
   AddType audio/mpeg .mp3 .m4a
   AddType video/mp4 .mp4 .m4v
+  AddType video/ogg .ogv
   AddType video/mpeg .mpeg .mpg .mpe
   AddType application/vnd.ms-project .mpp
   AddType application/x-font-otf .otf


### PR DESCRIPTION
At the moment W3TC doesn't support Browser Cache via .htaccess for video/ogg files. The pull request solves this. 

Therewith the expiring header is also set for those video files. 