### PR TITLE
 Parameter must be an array or an object that implements Countable

### DIFF
--- a/lib/Azure/GuzzleHttp/Handler/CurlFactory.php
+++ b/lib/Azure/GuzzleHttp/Handler/CurlFactory.php
@@ -64,7 +64,7 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (count($this->handles) >= $this->maxHandles) {
+        if ( $this->handles != null && count($this->handles) >= $this->maxHandles ) {
             curl_close($resource);
         } else {
             // Remove all callback functions as they can hold onto references


### PR DESCRIPTION
PHP Warning: count(): Parameter must be an array or an object that implements Countable in /home/landscape/public_html/wp-content/plugins/w3-total-cache/lib/Azure/GuzzleHttp/Handler/CurlFactory.php on line 67

https://wordpress.org/support/topic/parameter-must-be-an-array-or-an-object-that-implements-countable-w3-total-cach-2/