### PR TITLE
do get_pagenum_link filter with both args

### DIFF
--- a/Util_PageUrls.php
+++ b/Util_PageUrls.php
@@ -511,7 +511,7 @@ class Util_PageUrls {
 		}
 
 		$result = $base . $request . $query_string;
-		$result = apply_filters( 'get_pagenum_link', $result );
+		$result = apply_filters( 'get_pagenum_link', $result, $pagenum );
 		return $result;
 	}
 


### PR DESCRIPTION
Required by the [get_pagenum_link](https://developer.wordpress.org/reference/functions/get_pagenum_link/) filter. Otherwise fails with:
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function {closure}(), 1 passed in /wp-includes/class-wp-hook.php on line 287 and exactly 2 expected in /wp-content/themes/.../functions.php:684
Stack trace:
#0 /wp-includes/class-wp-hook.php(287): {closure}()
#1 /wp-includes/plugin.php(212): WP_Hook->apply_filters()
#2 /wp-content/plugins/w3-total-cache/Util_PageUrls.php(514): apply_filters()
#3 /wp-content/plugins/w3-total-cache/Util_PageUrls.php(458): W3TC\Util_PageUrls::get_pagenum_link_admin()
#4 /wp-content/plugins/w3-total-cache/Util_PageUrls.php(77): W3TC\Util_PageUrls::get_pagenum_link()
#5 /wp-content/plugins/w3-total-cache/Util_PageUrls.php(27): W3TC\Util_PageUrls::get_older
```
when used like this:
```php
add_filter('get_pagenum_link', function(string $result, int $pagenum): string {
    return $result;
}, 10, 2);
```