### PR TITLE
dont remove spaces around <li> tags since it's often inline-block, fixes #273

### DIFF
--- a/lib/Minify/Minify/HTML.php
+++ b/lib/Minify/Minify/HTML.php
@@ -142,7 +142,7 @@ class Minify_HTML {
 		// remove ws around block/undisplayed elements
 		$this->_html = preg_replace('/\\s+(<\\/?(?:area|article|aside|base(?:font)?|blockquote|body'
 			.'|canvas|caption|center|col(?:group)?|dd|dir|div|dl|dt|fieldset|figcaption|figure|footer|form'
-			.'|frame(?:set)?|h[1-6]|head|header|hgroup|hr|html|legend|li|link|main|map|menu|meta|nav'
+			.'|frame(?:set)?|h[1-6]|head|header|hgroup|hr|html|legend|link|main|map|menu|meta|nav'
 			.'|ol|opt(?:group|ion)|output|p|param|section|t(?:able|body|head|d|h||r|foot|itle)'
 			.'|ul|video)\\b[^>]*>)/i', '$1', $this->_html);
 


### PR DESCRIPTION
spaces should be removed around display:block <li> tags which are they
by default, but that specific tag is often used for menus with
display:inline-block, when spaces around tags matter.