### PR TITLE
Fix issue 6

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -161,6 +161,11 @@ $keys = array(
 		)
 	),
 
+	'docroot_fix.enable' => array(
+		'type' => 'boolean',
+		'default' => false,
+	),
+
 	'lazyload.enabled' => array(
 		'type' => 'boolean',
 		'default' => false

--- a/Minify_ContentMinifier.php
+++ b/Minify_ContentMinifier.php
@@ -158,9 +158,10 @@ class Minify_ContentMinifier {
 			);
 
 			$symlinks = $this->_config->get_array( 'minify.symlinks' );
+			$docroot  = Util_Environment::document_root();
 
 			foreach ( $symlinks as $link => $target ) {
-				$link = str_replace( '//', realpath( $_SERVER['DOCUMENT_ROOT'] ), $link );
+				$link = str_replace( '//', realpath( $docroot ), $link );
 				$link = strtr( $link, '/', DIRECTORY_SEPARATOR );
 				$options['symlinks'][$link] = realpath( $target );
 			}

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -532,7 +532,7 @@ class Minify_MinifiedFileRequestHandler {
 				} else {
 					$path = Util_Environment::docroot_to_full_filename( $docroot_filename );
 
-					if ( file_exists( $path ) ) {
+					if ( ! empty( $docroot_filename ) && file_exists( $path ) ) {
 						$result[] = $file;
 					} else {
 						Minify_Core::debug_error( sprintf( 'File "%s" doesn\'t exist', $file ) );

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -529,10 +529,10 @@ class Minify_MinifiedFileRequestHandler {
 					} else {
 						Minify_Core::debug_error( sprintf( 'Unable to cache remote file: "%s"', $file ) );
 					}
-				} elseif ( ! empty( $docroot_filename ) ) {
+				} else {
 					$path = Util_Environment::docroot_to_full_filename( $docroot_filename );
 
-					if ( file_exists( $path ) ) {
+					if ( @file_exists( $path ) ) {
 						$result[] = $file;
 					} else {
 						Minify_Core::debug_error( sprintf( 'File "%s" doesn\'t exist', $file ) );

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -529,10 +529,10 @@ class Minify_MinifiedFileRequestHandler {
 					} else {
 						Minify_Core::debug_error( sprintf( 'Unable to cache remote file: "%s"', $file ) );
 					}
-				} else {
+				} elseif ( ! empty( $docroot_filename ) ) {
 					$path = Util_Environment::docroot_to_full_filename( $docroot_filename );
 
-					if ( ! empty( $docroot_filename ) && file_exists( $path ) ) {
+					if ( file_exists( $path ) ) {
 						$result[] = $file;
 					} else {
 						Minify_Core::debug_error( sprintf( 'File "%s" doesn\'t exist', $file ) );

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -549,6 +549,14 @@ class Util_Environment {
 		if ( !is_null( $document_root ) )
 			return $document_root;
 
+		$c = Dispatcher::config();
+		$docroot_fix = $c->get_boolean( 'docroot_fix.enable' );
+
+		if ( $docroot_fix ) {
+			$document_root = untrailingslashit( ABSPATH );
+			return $document_root;
+		}
+
 		if ( !empty( $_SERVER['SCRIPT_FILENAME'] ) &&
 			!empty( $_SERVER['PHP_SELF'] ) ) {
 			$script_filename = Util_Environment::normalize_path(

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -515,7 +515,11 @@ Util_Ui::config_item( array(
 						'control'        => 'checkbox',
 						'checkbox_label' => __( 'Fix document root path', 'w3-total-cache' ),
 						'label_class'    => 'w3tc_single_column',
-						'description'    => __( 'Fix incorrect server document root path.  Uses ABSPATH.', 'w3-total-cache' ),
+						'description'    => sprintf(
+							__( 'Fix incorrect server document root path.  Uses the WordPress ABSPATH ("%1$s") in place of the current server document root ("%2$s").', 'w3-total-cache' ),
+							esc_html( $_SERVER['DOCUMENT_ROOT'] ),
+							esc_html( untrailingslashit( ABSPATH ) )
+						),
 					)
 				);
 

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -516,9 +516,10 @@ Util_Ui::config_item( array(
 						'checkbox_label' => __( 'Fix document root path', 'w3-total-cache' ),
 						'label_class'    => 'w3tc_single_column',
 						'description'    => sprintf(
+							// translators: 1: WordPress ABSPATH value, 2: Server document root value.
 							__( 'Fix incorrect server document root path.  Uses the WordPress ABSPATH ("%1$s") in place of the current server document root ("%2$s").', 'w3-total-cache' ),
-							esc_html( $_SERVER['DOCUMENT_ROOT'] ),
-							esc_html( untrailingslashit( ABSPATH ) )
+							esc_html( untrailingslashit( ABSPATH ) ),
+							esc_html( $_SERVER['DOCUMENT_ROOT'] )
 						),
 					)
 				);

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -508,6 +508,17 @@ Util_Ui::config_item( array(
 				</th>
 			</tr>
 			<?php
+
+				Util_Ui::config_item(
+					array(
+						'key'            => 'docroot_fix.enable',
+						'control'        => 'checkbox',
+						'checkbox_label' => __( 'Fix document root path', 'w3-total-cache' ),
+						'label_class'    => 'w3tc_single_column',
+						'description'    => __( 'Fix incorrect server document root path.  Uses ABSPATH.', 'w3-total-cache' ),
+					)
+				);
+
 Util_Ui::config_item( array(
 		'key' => 'common.track_usage',
 		'control' => 'checkbox',

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -159,7 +159,7 @@ if ( file_exists( $html_engine_file2 ) ) {
 						)
 					)
 				) );
-			endif; 
+			endif;
 			?>
 			<tr>
 				<th><?php _e( 'Minify engine settings:', 'w3-total-cache' ); ?></th>

--- a/lib/Minify/Minify/Build.php
+++ b/lib/Minify/Minify/Build.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File: Build.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
 namespace W3TCL\Minify;
 
 /**
@@ -85,13 +91,16 @@ class Minify_Build {
 	 */
 	public function __construct($sources)
 	{
+		// W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+		$docroot = \W3TC\Util_Environment::document_root();
+
 		$max = 0;
 		foreach ((array)$sources as $source) {
 			if ($source instanceof Minify_Source) {
 				$max = max($max, $source->lastModified);
 			} elseif (is_string($source)) {
 				if (0 === strpos($source, '//')) {
-					$source = $_SERVER['DOCUMENT_ROOT'] . substr($source, 1);
+					$source = $docroot . substr($source, 1);
 				}
 				if (is_file($source)) {
 					$max = max($max, filemtime($source));

--- a/lib/Minify/Minify/CSS.php
+++ b/lib/Minify/Minify/CSS.php
@@ -1,5 +1,11 @@
 <?php
-namespace W3TCL\Minify;
+/**
+ * File: CSS.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
+ namespace W3TCL\Minify;
 /**
  * Class Minify_CSS
  * @package Minify
@@ -56,12 +62,15 @@ class Minify_CSS {
 	 */
 	public static function minify($css, $options = array())
 	{
+		// W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+		$docroot = \W3TC\Util_Environment::document_root();
+
 		$options = array_merge(array(
 			'compress' => true,
 			'removeCharsets' => true,
 			'preserveComments' => true,
 			'currentDir' => null,
-			'docRoot' => $_SERVER['DOCUMENT_ROOT'],
+			'docRoot' => $docroot,
 			'prependRelativePath' => null,
 			'symlinks' => array(),
 		), $options);

--- a/lib/Minify/Minify/CSS/UriRewriter.php
+++ b/lib/Minify/Minify/CSS/UriRewriter.php
@@ -1,5 +1,11 @@
 <?php
-namespace W3TCL\Minify;
+/**
+ * File: UriRewriter.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
+ namespace W3TCL\Minify;
 /**
  * Class Minify_CSS_UriRewriter
  * @package Minify
@@ -54,8 +60,11 @@ class Minify_CSS_UriRewriter {
 			(isset($options['browserCacheExtensions']) ?
 			$options['browserCacheExtensions'] : array());
 
+		// W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+		$docroot = \W3TC\Util_Environment::document_root();
+
 		if (isset($options['currentDir'])) {
-			$document_root = (isset($options['docRoot']) ? $options['docRoot'] : $_SERVER['DOCUMENT_ROOT']);
+			$document_root = (isset($options['docRoot']) ? $options['docRoot'] : $docroot);
 			$symlinks = (isset($options['symlinks']) ? $options['symlinks'] : array());
 			$prependAbsolutePath = (isset($options['prependAbsolutePath']) ? $options['prependAbsolutePath'] : '');
 			$prependAbsolutePathCallback = (isset($options['prependAbsolutePathCallback']) ? $options['prependAbsolutePathCallback'] : '');
@@ -111,8 +120,11 @@ class Minify_CSS_UriRewriter {
 	private static function _rewrite($css, $currentDir,
 			$prependAbsolutePath = null, $prependAbsolutePathCallback = null,
 			$docRoot = null, $symlinks = array()) {
+				// W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+				$docroot = \W3TC\Util_Environment::document_root();
+
 		self::$_docRoot = self::_realpath(
-			$docRoot ? $docRoot : $_SERVER['DOCUMENT_ROOT']
+			$docRoot ? $docRoot : $docroot
 		);
 		self::$_currentDir = self::_realpath($currentDir);
 		self::$_prependAbsolutePath = $prependAbsolutePath;

--- a/lib/Minify/Minify/Controller/Files.php
+++ b/lib/Minify/Minify/Controller/Files.php
@@ -38,6 +38,9 @@ class Minify_Controller_Files extends Minify_Controller_Base {
      * 'files': (required) array of complete file paths, or a single path
      */
     public function setupSources($options) {
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         // strip controller options
 
         $files = $options['files'];
@@ -59,7 +62,7 @@ class Minify_Controller_Files extends Minify_Controller_Base {
             	if ( is_file( ABSPATH . substr($file, 1) ) ) {
 		            $file = ABSPATH . substr( $file, 1 );
 	            } else {
-		            $file = $_SERVER['DOCUMENT_ROOT'] . substr( $file, 1 );
+		            $file = $docroot . substr( $file, 1 );
 	            }
             }
             $realPath = realpath($file);

--- a/lib/Minify/Minify/Controller/Groups.php
+++ b/lib/Minify/Minify/Controller/Groups.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File: Groups.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
 namespace W3TCL\Minify;
 /**
  * Class Minify_Controller_Groups
@@ -65,13 +71,17 @@ class Minify_Controller_Groups extends Minify_Controller_Base {
         } elseif (! is_array($files)) {
             $files = (array)$files;
         }
+
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         foreach ($files as $file) {
             if ($file instanceof Minify_Source) {
                 $sources[] = $file;
                 continue;
             }
             if (0 === strpos($file, '//')) {
-                $file = $_SERVER['DOCUMENT_ROOT'] . substr($file, 1);
+                $file = $docroot . substr($file, 1);
             }
             $realPath = realpath($file);
             if (is_file($realPath)) {

--- a/lib/Minify/Minify/Controller/MinApp.php
+++ b/lib/Minify/Minify/Controller/MinApp.php
@@ -3,6 +3,8 @@ namespace W3TCL\Minify;
 /**
  * Class Minify_Controller_MinApp
  * @package Minify
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
  */
 
 /**
@@ -21,6 +23,9 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
      * @return array Minify options
      */
     public function setupSources($options) {
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         // PHP insecure by default: realpath() and other FS functions can't handle null bytes.
         foreach (array('g', 'b', 'f') as $key) {
             if (isset($_GET[$key])) {
@@ -69,7 +74,10 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
                         continue;
                     }
                     if (0 === strpos($file, '//')) {
-                        $file = $_SERVER['DOCUMENT_ROOT'] . substr($file, 1);
+                        //$file = $_SERVER['DOCUMENT_ROOT'] . substr($file, 1);
+
+                        // W3TC FIX.
+                        $file = $docroot . substr($file, 1);
                     }
                     $realpath = \W3TC\Util_Environment::realpath($file);
                     if ($realpath && is_file($realpath)) {
@@ -118,7 +126,10 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
             }
             $allowDirs = array();
             foreach ((array)$cOptions['allowDirs'] as $allowDir) {
-                $allowDirs[] = \W3TC\Util_Environment::realpath(str_replace('//', $_SERVER['DOCUMENT_ROOT'] . '/', $allowDir));
+                //$allowDirs[] = \W3TC\Util_Environment::realpath(str_replace('//', $_SERVER['DOCUMENT_ROOT'] . '/', $allowDir));
+
+                // W3TC FIX.
+                $allowDirs[] = \W3TC\Util_Environment::realpath(str_replace('//', $docroot . '/', $allowDir));
             }
             $basenames = array(); // just for cache id
             foreach ($files as $file) {
@@ -128,7 +139,12 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
                 }
 
                 $uri = $base . $file;
-                $path = $_SERVER['DOCUMENT_ROOT'] . $uri;
+
+                //$path = $_SERVER['DOCUMENT_ROOT'] . $uri;
+
+                // W3TC FIX.
+                $path = $docroot . $uri;
+
                 $realpath = \W3TC\Util_Environment::realpath($path);
                 if (false === $realpath || ! is_file($realpath)) {
                     $this->log("The path \"{$path}\" (realpath \"{$realpath}\") could not be found (or was not a file)");

--- a/lib/Minify/Minify/Controller/Version1.php
+++ b/lib/Minify/Minify/Controller/Version1.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * File: Version1.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
 namespace W3TCL\Minify;
 /**
  * Class Minify_Controller_Version1
@@ -61,10 +66,13 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
             return $options;
         }
 
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         // strings for prepending to relative/absolute paths
         $prependRelPaths = dirname($_SERVER['SCRIPT_FILENAME'])
             . DIRECTORY_SEPARATOR;
-        $prependAbsPaths = $_SERVER['DOCUMENT_ROOT'];
+        $prependAbsPaths = $docroot;
 
         $goodFiles = array();
         $hasBadSource = false;
@@ -103,8 +111,11 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
 
     private static function _setupDefines()
     {
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         $defaults = array(
-            'MINIFY_BASE_DIR' => realpath($_SERVER['DOCUMENT_ROOT'])
+            'MINIFY_BASE_DIR' => realpath($docroot)
             ,'MINIFY_ENCODING' => 'utf-8'
             ,'MINIFY_MAX_FILES' => 16
             ,'MINIFY_REWRITE_CSS_URLS' => true

--- a/lib/Minify/Minify/HTML/Helper.php
+++ b/lib/Minify/Minify/HTML/Helper.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File: Helper.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
 namespace W3TCL\Minify;
 /**
  * Class Minify_HTML_Helper
@@ -87,6 +93,9 @@ class Minify_HTML_Helper {
      */
     public function setFiles($files, $checkLastModified = true)
     {
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         $this->_groupKey = null;
         if ($checkLastModified) {
             $this->_lastModified = self::getLastModified($files);
@@ -97,7 +106,7 @@ class Minify_HTML_Helper {
                 $file = substr($file, 2);
             } elseif (0 === strpos($file, '/')
                       || 1 === strpos($file, ':\\')) {
-                $file = substr($file, strlen($_SERVER['DOCUMENT_ROOT']) + 1);
+                $file = substr($file, strlen($docroot) + 1);
             }
             $file = strtr($file, '\\', '/');
             $files[$k] = $file;
@@ -139,13 +148,16 @@ class Minify_HTML_Helper {
      */
     public static function getLastModified($sources, $lastModified = 0)
     {
+        // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+        $docroot = \W3TC\Util_Environment::document_root();
+
         $max = $lastModified;
         foreach ((array)$sources as $source) {
             if (is_object($source) && isset($source->lastModified)) {
                 $max = max($max, $source->lastModified);
             } elseif (is_string($source)) {
                 if (0 === strpos($source, '//')) {
-                    $source = $_SERVER['DOCUMENT_ROOT'] . substr($source, 1);
+                    $source = $docroot . substr($source, 1);
                 }
                 if (is_file($source)) {
                     $max = max($max, filemtime($source));

--- a/lib/Minify/Minify/HTMLTidy.php
+++ b/lib/Minify/Minify/HTMLTidy.php
@@ -14,7 +14,8 @@ class Minify_HTMLTidy {
             'show-errors' => 0,
             'show-warnings' => false,
             'force-output' => true,
-            'tidy-mark' => false
+            'tidy-mark' => false,
+            'output-xhtml' => false,
         ));
 
         $tidy = new \tidy();

--- a/lib/Minify/Minify/HTMLTidy.php
+++ b/lib/Minify/Minify/HTMLTidy.php
@@ -17,7 +17,7 @@ class Minify_HTMLTidy {
             'tidy-mark' => false
         ));
 
-        $tidy = new tidy();
+        $tidy = new \tidy();
         $tidy->parseString($content, $options);
         $tidy->cleanRepair();
 

--- a/lib/Minify/Minify/ImportProcessor.php
+++ b/lib/Minify/Minify/ImportProcessor.php
@@ -116,7 +116,11 @@ class Minify_ImportProcessor {
         if ('/' === $url[0]) {
             // protocol-relative or root path
             $url = ltrim($url, '/');
-            $file = realpath($_SERVER['DOCUMENT_ROOT']) . DIRECTORY_SEPARATOR
+
+            // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+            $docroot = \W3TC\Util_Environment::document_root();
+
+            $file = realpath($docroot) . DIRECTORY_SEPARATOR
                 . strtr($url, '/', DIRECTORY_SEPARATOR);
         } else {
             // relative to current path

--- a/lib/Minify/Minify/Lines.php
+++ b/lib/Minify/Minify/Lines.php
@@ -1,5 +1,12 @@
 <?php
+/**
+ * File: Lines.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
 namespace W3TCL\Minify;
+
 /**
  * Class Minify_Lines
  * @package Minify
@@ -68,7 +75,11 @@ class Minify_Lines
 		// check for desired URI rewriting
 		if (isset($options['currentDir'])) {
 			Minify_CSS_UriRewriter::$debugText = '';
-			$docRoot = isset($options['docRoot']) ? $options['docRoot'] : $_SERVER['DOCUMENT_ROOT'];
+
+			// W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+			$docroot = \W3TC\Util_Environment::document_root();
+
+			$docRoot = isset($options['docRoot']) ? $options['docRoot'] : $docroot;
 			$symlinks = isset($options['symlinks']) ? $options['symlinks'] : array();
 
 			$content = Minify_CSS_UriRewriter::rewrite($content, $options['currentDir'], $docRoot, $symlinks);

--- a/lib/Minify/Minify/Source.php
+++ b/lib/Minify/Minify/Source.php
@@ -1,5 +1,12 @@
 <?php
+/**
+ * File: Source.php
+ *
+ * NOTE: Fixes have been included in this file; look for "W3TC FIX".
+ */
+
 namespace W3TCL\Minify;
+
 /**
  * Class Minify_Source
  * @package Minify
@@ -58,7 +65,10 @@ class Minify_Source {
     {
         if (isset($spec['filepath'])) {
             if (0 === strpos($spec['filepath'], '//')) {
-                $spec['filepath'] = $_SERVER['DOCUMENT_ROOT'] . substr($spec['filepath'], 1);
+                // W3TC FIX: Override $_SERVER['DOCUMENT_ROOT'] if enabled in settings.
+                $docroot = \W3TC\Util_Environment::document_root();
+
+                $spec['filepath'] = $docroot . substr($spec['filepath'], 1);
             }
             $segments = explode('.', $spec['filepath']);
             $ext = strtolower(array_pop($segments));


### PR DESCRIPTION
This fix addresses the issue of an incorrect server document root, broken loading for PHP Tidy, and a CDATA wrapper that caused syntax errors.

To simulate an incorrect server document root path, use the following code in `wp-config.php`:
```
$_SERVER['DOCUMENT_ROOT'] = '/var/www/html';
```
