### PR TITLE
Fix admin URLs for multisite installs.  Fixes #357

### DIFF
--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -137,6 +137,13 @@ class FeatureShowcase_Plugin_Admin {
 	 * @return int
 	 */
 	public static function get_unseen_count() {
+		$config              = Dispatcher::config();
+		$force_master_config = $config->get_boolean( 'common.force_master' );
+
+		if ( is_multisite() && $force_master_config && ! is_super_admin() ) {
+			return 0;
+		}
+
 		global $current_user;
 
 		$unseen_count  = 0;
@@ -164,13 +171,19 @@ class FeatureShowcase_Plugin_Admin {
 	 * @return array
 	 */
 	private static function get_cards() {
+		$config              = Dispatcher::config();
+		$force_master_config = $config->get_boolean( 'common.force_master' );
+
 		return array(
 			'setup_guide'         => array(
 				'title'      => esc_html__( 'Setup Guide Wizard', 'w3-total-cache' ),
 				'icon'       => 'dashicons-superhero',
 				'text'       => esc_html__( 'The Setup Guide wizard quickly walks you through configuring W3 Total Cache.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_setup_guide' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_setup_guide' ) : admin_url( 'admin.php?page=w3tc_setup_guide' )
+					) . '\'">' .
 					__( 'Launch', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/setup-guide-wizard/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=setup_guide' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -182,7 +195,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-admin-site',
 				'text'       => esc_html__( 'Defer loading offscreen Google Maps, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_userexperience' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_userexperience' ) : admin_url( 'admin.php?page=w3tc_userexperience' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/lazy-load-google-maps/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_lazyload_googlemaps' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -194,7 +210,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-networking',
 				'text'       => esc_html__( 'Provide the best user experience possible by enhancing by hosting HTML pages and RSS feeds with (supported) CDN\'s high speed global networks.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#cdn' ) : admin_url( 'admin.php?page=w3tc_general#cdn' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/cdn-full-site-delivery/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_cdn_fsd' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -206,7 +225,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-table-row-delete',
 				'text'       => esc_html__( 'Render blocking CSS delays a webpage from being visible in a timely manner. Eliminate this easily with the click of a button in W3 Total Cache Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_minify#css' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_minify#css' ) : admin_url( 'admin.php?page=w3tc_minify#css' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/how-to-use-manual-minify-for-css-and-js/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_minify_CSS' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -218,7 +240,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-insert',
 				'text'       => esc_html__( 'Improve the performance of your Genesis, WPML powered site, and much more. StudioPress\' Genesis Framework is up to 60% faster with W3TC Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_extensions' ) : admin_url( 'admin.php?page=w3tc_extensions' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/extension-framework-pro/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_extensions' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -230,7 +255,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-chart-pie',
 				'text'       => esc_html__( 'Unlocking the fragment caching module delivers enhanced performance for plugins and themes that use the WordPress Transient API.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#fragmentcache' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#fragmentcache' ) : admin_url( 'admin.php?page=w3tc_general#fragmentcache' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-fragment-caching-method-for-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_fragment_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -242,7 +270,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-embed-generic',
 				'text'       => esc_html__( 'Save server resources or add scale and performance by caching the WordPress Rest API with W3TC Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_pgcache#rest' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_pgcache#rest' ) : admin_url( 'admin.php?page=w3tc_pgcache#rest' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/achieve-ultimate-wordpress-performance-with-w3-total-cache-pro/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_rest_api_caching' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -254,7 +285,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-chart-line',
 				'text'       => esc_html__( 'Analytics for your WordPress and Server cache that allow you to track the size, time and hit/miss ratio of each type of cache, giving you the information needed to gain maximum performance.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_stats' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_stats' ) : admin_url( 'admin.php?page=w3tc_stats' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-w3-total-cache-statistics-to-give-detailed-information-about-your-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_stats' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -266,7 +300,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-search',
 				'text'       => esc_html__( 'Purge Logs provide information on when your cache has been purged and what triggered it. If you are troubleshooting an issue with your cache being cleared, Purge Logs can tell you why.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#debug' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#debug' ) : admin_url( 'admin.php?page=w3tc_general#debug' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/purge-cache-log/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_purge_logs' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -278,7 +315,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-aside',
 				'text'       => esc_html__( 'Page caching decreases the website response time, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#page_cache' ) : admin_url( 'admin.php?page=w3tc_general#page_cache' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-page-caching-in-w3-total-cache-for-shared-hosting/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=page_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -290,7 +330,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-media-text',
 				'text'       => esc_html__( 'Reduce load time by decreasing the size and number of CSS and JS files.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#minify' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#minify' ) : admin_url( 'admin.php?page=w3tc_general#minify' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-minification-method-for-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=minify' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -302,7 +345,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-image',
 				'text'       => esc_html__( 'Defer loading offscreen images, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#userexperience' ) : admin_url( 'admin.php?page=w3tc_general#userexperience' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-lazy-loading-for-your-wordpress-website-with-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=lazyload' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -314,7 +360,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-gallery',
 				'text'       => esc_html__( 'Host static files with a CDN to reduce page load time.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#cdn' ) : admin_url( 'admin.php?page=w3tc_general#cdn' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-w3-total-cache-with-stackpath-for-cdn-objects/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=cdn' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -326,7 +375,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-performance',
 				'text'       => esc_html__( 'Improves PHP performance by storing precompiled script bytecode in shared memory.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#system_opcache' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#system_opcache' ) : admin_url( 'admin.php?page=w3tc_general#system_opcache' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-an-opcode-caching-method-with-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=opcode_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -338,7 +390,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-database-view',
 				'text'       => esc_html__( 'Persistently store data to reduce post, page and feed creation time.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#database_cache' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#database_cache' ) : admin_url( 'admin.php?page=w3tc_general#database_cache' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-database-caching-method-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=database_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -350,7 +405,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-archive',
 				'text'       => esc_html__( 'Persistently store objects to reduce execution time for common operations.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#object_cache' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#object_cache' ) : admin_url( 'admin.php?page=w3tc_general#object_cache' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-object-caching-methods-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=object_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -362,7 +420,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-welcome-widgets-menus',
 				'text'       => esc_html__( 'Reduce server load and decrease response time by using the cache available in site visitor\'s web browser.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_general#browser_cache' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_general#browser_cache' ) : admin_url( 'admin.php?page=w3tc_general#browser_cache' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=browser_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -374,7 +435,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-editor-kitchensink',
 				'text'       => esc_html__( 'Additional features to extend the functionality of W3 Total Cache, such as Accelerated Mobile Pages (AMP) for Minify and support for New Relic.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_extensions' ) : admin_url( 'admin.php?page=w3tc_extensions' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/extension-framework/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=extensions' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -386,7 +450,10 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-image-filter',
 				'text'       => esc_html__( 'Manage cache groups for user agents, referrers, and cookies.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( network_admin_url( 'admin.php?page=w3tc_cachegroups' ) ) . '\'">' .
+					esc_url(
+						$force_master_config || is_network_admin() ?
+						network_admin_url( 'admin.php?page=w3tc_cachegroups' ) : admin_url( 'admin.php?page=w3tc_cachegroups' )
+					) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/cache-groups/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=cache_groups' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',

--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -171,19 +171,13 @@ class FeatureShowcase_Plugin_Admin {
 	 * @return array
 	 */
 	private static function get_cards() {
-		$config              = Dispatcher::config();
-		$force_master_config = $config->get_boolean( 'common.force_master' );
-
 		return array(
 			'setup_guide'         => array(
 				'title'      => esc_html__( 'Setup Guide Wizard', 'w3-total-cache' ),
 				'icon'       => 'dashicons-superhero',
 				'text'       => esc_html__( 'The Setup Guide wizard quickly walks you through configuring W3 Total Cache.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_setup_guide' ) : admin_url( 'admin.php?page=w3tc_setup_guide' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_setup_guide' ) ) . '\'">' .
 					__( 'Launch', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/setup-guide-wizard/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=setup_guide' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -195,10 +189,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-admin-site',
 				'text'       => esc_html__( 'Defer loading offscreen Google Maps, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_userexperience' ) : admin_url( 'admin.php?page=w3tc_userexperience' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_userexperience' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/lazy-load-google-maps/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_lazyload_googlemaps' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -210,10 +201,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-networking',
 				'text'       => esc_html__( 'Provide the best user experience possible by enhancing by hosting HTML pages and RSS feeds with (supported) CDN\'s high speed global networks.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#cdn' ) : admin_url( 'admin.php?page=w3tc_general#cdn' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/cdn-full-site-delivery/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_cdn_fsd' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -225,10 +213,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-table-row-delete',
 				'text'       => esc_html__( 'Render blocking CSS delays a webpage from being visible in a timely manner. Eliminate this easily with the click of a button in W3 Total Cache Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_minify#css' ) : admin_url( 'admin.php?page=w3tc_minify#css' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_minify#css' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/how-to-use-manual-minify-for-css-and-js/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_minify_CSS' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -240,10 +225,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-insert',
 				'text'       => esc_html__( 'Improve the performance of your Genesis, WPML powered site, and much more. StudioPress\' Genesis Framework is up to 60% faster with W3TC Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_extensions' ) : admin_url( 'admin.php?page=w3tc_extensions' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/extension-framework-pro/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_extensions' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -255,10 +237,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-chart-pie',
 				'text'       => esc_html__( 'Unlocking the fragment caching module delivers enhanced performance for plugins and themes that use the WordPress Transient API.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#fragmentcache' ) : admin_url( 'admin.php?page=w3tc_general#fragmentcache' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#fragmentcache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-fragment-caching-method-for-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_fragment_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -270,10 +249,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-embed-generic',
 				'text'       => esc_html__( 'Save server resources or add scale and performance by caching the WordPress Rest API with W3TC Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_pgcache#rest' ) : admin_url( 'admin.php?page=w3tc_pgcache#rest' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_pgcache#rest' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/achieve-ultimate-wordpress-performance-with-w3-total-cache-pro/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_rest_api_caching' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -285,10 +261,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-chart-line',
 				'text'       => esc_html__( 'Analytics for your WordPress and Server cache that allow you to track the size, time and hit/miss ratio of each type of cache, giving you the information needed to gain maximum performance.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_stats' ) : admin_url( 'admin.php?page=w3tc_stats' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_stats' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-w3-total-cache-statistics-to-give-detailed-information-about-your-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_stats' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -300,10 +273,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-search',
 				'text'       => esc_html__( 'Purge Logs provide information on when your cache has been purged and what triggered it. If you are troubleshooting an issue with your cache being cleared, Purge Logs can tell you why.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#debug' ) : admin_url( 'admin.php?page=w3tc_general#debug' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#debug' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/purge-cache-log/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_purge_logs' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -315,10 +285,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-aside',
 				'text'       => esc_html__( 'Page caching decreases the website response time, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#page_cache' ) : admin_url( 'admin.php?page=w3tc_general#page_cache' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-page-caching-in-w3-total-cache-for-shared-hosting/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=page_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -330,10 +297,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-media-text',
 				'text'       => esc_html__( 'Reduce load time by decreasing the size and number of CSS and JS files.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#minify' ) : admin_url( 'admin.php?page=w3tc_general#minify' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#minify' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-minification-method-for-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=minify' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -345,10 +309,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-image',
 				'text'       => esc_html__( 'Defer loading offscreen images, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#userexperience' ) : admin_url( 'admin.php?page=w3tc_general#userexperience' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-lazy-loading-for-your-wordpress-website-with-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=lazyload' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -360,10 +321,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-gallery',
 				'text'       => esc_html__( 'Host static files with a CDN to reduce page load time.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#cdn' ) : admin_url( 'admin.php?page=w3tc_general#cdn' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-w3-total-cache-with-stackpath-for-cdn-objects/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=cdn' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -375,10 +333,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-performance',
 				'text'       => esc_html__( 'Improves PHP performance by storing precompiled script bytecode in shared memory.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#system_opcache' ) : admin_url( 'admin.php?page=w3tc_general#system_opcache' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#system_opcache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-an-opcode-caching-method-with-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=opcode_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -390,10 +345,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-database-view',
 				'text'       => esc_html__( 'Persistently store data to reduce post, page and feed creation time.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#database_cache' ) : admin_url( 'admin.php?page=w3tc_general#database_cache' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#database_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-database-caching-method-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=database_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -405,10 +357,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-archive',
 				'text'       => esc_html__( 'Persistently store objects to reduce execution time for common operations.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#object_cache' ) : admin_url( 'admin.php?page=w3tc_general#object_cache' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#object_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-object-caching-methods-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=object_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -420,10 +369,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-welcome-widgets-menus',
 				'text'       => esc_html__( 'Reduce server load and decrease response time by using the cache available in site visitor\'s web browser.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_general#browser_cache' ) : admin_url( 'admin.php?page=w3tc_general#browser_cache' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_general#browser_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=browser_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -435,10 +381,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-editor-kitchensink',
 				'text'       => esc_html__( 'Additional features to extend the functionality of W3 Total Cache, such as Accelerated Mobile Pages (AMP) for Minify and support for New Relic.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_extensions' ) : admin_url( 'admin.php?page=w3tc_extensions' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/extension-framework/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=extensions' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -450,10 +393,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-image-filter',
 				'text'       => esc_html__( 'Manage cache groups for user agents, referrers, and cookies.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url(
-						$force_master_config || is_network_admin() ?
-						network_admin_url( 'admin.php?page=w3tc_cachegroups' ) : admin_url( 'admin.php?page=w3tc_cachegroups' )
-					) . '\'">' .
+					esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_cachegroups' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/cache-groups/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=cache_groups' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',

--- a/FeatureShowcase_Plugin_Admin.php
+++ b/FeatureShowcase_Plugin_Admin.php
@@ -170,7 +170,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-superhero',
 				'text'       => esc_html__( 'The Setup Guide wizard quickly walks you through configuring W3 Total Cache.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_setup_guide' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_setup_guide' ) ) . '\'">' .
 					__( 'Launch', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/setup-guide-wizard/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=setup_guide' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -182,7 +182,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-admin-site',
 				'text'       => esc_html__( 'Defer loading offscreen Google Maps, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_userexperience' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_userexperience' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/lazy-load-google-maps/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_lazyload_googlemaps' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -194,7 +194,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-networking',
 				'text'       => esc_html__( 'Provide the best user experience possible by enhancing by hosting HTML pages and RSS feeds with (supported) CDN\'s high speed global networks.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/cdn-full-site-delivery/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_cdn_fsd' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -206,7 +206,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-table-row-delete',
 				'text'       => esc_html__( 'Render blocking CSS delays a webpage from being visible in a timely manner. Eliminate this easily with the click of a button in W3 Total Cache Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_minify#css' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_minify#css' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/how-to-use-manual-minify-for-css-and-js/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_minify_CSS' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -218,7 +218,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-insert',
 				'text'       => esc_html__( 'Improve the performance of your Genesis, WPML powered site, and much more. StudioPress\' Genesis Framework is up to 60% faster with W3TC Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/extension-framework-pro/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_extensions' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -230,7 +230,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-chart-pie',
 				'text'       => esc_html__( 'Unlocking the fragment caching module delivers enhanced performance for plugins and themes that use the WordPress Transient API.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#fragmentcache' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#fragmentcache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-fragment-caching-method-for-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_fragment_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -242,7 +242,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-embed-generic',
 				'text'       => esc_html__( 'Save server resources or add scale and performance by caching the WordPress Rest API with W3TC Pro.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_pgcache#rest' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_pgcache#rest' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/achieve-ultimate-wordpress-performance-with-w3-total-cache-pro/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_rest_api_caching' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -254,7 +254,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-chart-line',
 				'text'       => esc_html__( 'Analytics for your WordPress and Server cache that allow you to track the size, time and hit/miss ratio of each type of cache, giving you the information needed to gain maximum performance.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_stats' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_stats' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-w3-total-cache-statistics-to-give-detailed-information-about-your-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_stats' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -266,7 +266,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-search',
 				'text'       => esc_html__( 'Purge Logs provide information on when your cache has been purged and what triggered it. If you are troubleshooting an issue with your cache being cleared, Purge Logs can tell you why.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#debug' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#debug' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/purge-cache-log/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=pro_purge_logs' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -278,7 +278,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-aside',
 				'text'       => esc_html__( 'Page caching decreases the website response time, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#page_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-page-caching-in-w3-total-cache-for-shared-hosting/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=page_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -290,7 +290,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-media-text',
 				'text'       => esc_html__( 'Reduce load time by decreasing the size and number of CSS and JS files.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#minify' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#minify' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-minification-method-for-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=minify' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -302,7 +302,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-image',
 				'text'       => esc_html__( 'Defer loading offscreen images, making pages load faster.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#userexperience' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-lazy-loading-for-your-wordpress-website-with-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=lazyload' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -314,7 +314,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-format-gallery',
 				'text'       => esc_html__( 'Host static files with a CDN to reduce page load time.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-w3-total-cache-with-stackpath-for-cdn-objects/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=cdn' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -326,7 +326,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-performance',
 				'text'       => esc_html__( 'Improves PHP performance by storing precompiled script bytecode in shared memory.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#system_opcache' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#system_opcache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-an-opcode-caching-method-with-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=opcode_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -338,7 +338,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-database-view',
 				'text'       => esc_html__( 'Persistently store data to reduce post, page and feed creation time.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#database_cache' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#database_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/choosing-a-database-caching-method-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=database_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -350,7 +350,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-archive',
 				'text'       => esc_html__( 'Persistently store objects to reduce execution time for common operations.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#object_cache' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#object_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-object-caching-methods-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=object_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -362,7 +362,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-welcome-widgets-menus',
 				'text'       => esc_html__( 'Reduce server load and decrease response time by using the cache available in site visitor\'s web browser.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_general#browser_cache' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_general#browser_cache' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/configuring-browser-caching-in-w3-total-cache/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=browser_cache' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -374,7 +374,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-editor-kitchensink',
 				'text'       => esc_html__( 'Additional features to extend the functionality of W3 Total Cache, such as Accelerated Mobile Pages (AMP) for Minify and support for New Relic.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_extensions' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/extension-framework/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=extensions' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',
@@ -386,7 +386,7 @@ class FeatureShowcase_Plugin_Admin {
 				'icon'       => 'dashicons-image-filter',
 				'text'       => esc_html__( 'Manage cache groups for user agents, referrers, and cookies.', 'w3-total-cache' ),
 				'button'     => '<button class="button" onclick="window.location=\'' .
-					esc_url( admin_url( 'admin.php?page=w3tc_cachegroups' ) ) . '\'">' .
+					esc_url( network_admin_url( 'admin.php?page=w3tc_cachegroups' ) ) . '\'">' .
 					__( 'Settings', 'w3-total-cache' ) . '</button>',
 				'link'       => '<a target="_blank" href="' . esc_url( 'https://www.boldgrid.com/support/w3-total-cache/cache-groups/?utm_source=w3tc&utm_medium=feature_showcase&utm_campaign=cache_groups' ) .
 					'">' . __( 'More info', 'w3-total-cache' ) . '<span class="dashicons dashicons-external"></span></a>',

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -273,11 +273,7 @@ class Generic_Plugin_Admin {
 			$state_master = Dispatcher::config_state_master();
 
 			if ( ! $config->get_boolean( 'pgcache.enabled' ) && $state_master->get_integer( 'common.install' ) > strtotime( 'NOW - 1 WEEK' ) ) {
-				if ( is_multisite() ) {
-					wp_redirect( esc_url( network_admin_url( 'admin.php?page=w3tc_setup_guide' ) ) );
-				} else {
-					wp_redirect( esc_url( admin_url( 'admin.php?page=w3tc_setup_guide' ) ) );
-				}
+				wp_redirect( esc_url( network_admin_url( 'admin.php?page=w3tc_setup_guide' ) ) );
 			}
 		}
 

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -268,7 +268,7 @@ class Generic_Plugin_Admin {
 	function admin_head() {
 		$page = isset( $_GET['page'] ) ? $_GET['page'] : null;
 
-		if ( false !== strpos( $page, 'w3tc' ) && 'w3tc_setup_guide' !== $page && ! get_site_option( 'w3tc_setupguide_completed' ) ) {
+		if ( ( ! is_multisite() || is_super_admin() ) && false !== strpos( $page, 'w3tc' ) && 'w3tc_setup_guide' !== $page && ! get_site_option( 'w3tc_setupguide_completed' ) ) {
 			$config       = new Config();
 			$state_master = Dispatcher::config_state_master();
 

--- a/SetupGuide_Plugin_Admin.php
+++ b/SetupGuide_Plugin_Admin.php
@@ -934,7 +934,7 @@ class SetupGuide_Plugin_Admin {
 							'disk_enhanced'     => __( 'Disk: Enhanced', 'w3-total-cache' ),
 							'enabled'           => __( 'Enabled', 'w3-total-cache' ),
 							'notEnabled'        => __( 'Not Enabled', 'w3-total-cache' ),
-							'dashboardUrl'      => esc_url( admin_url( 'admin.php?page=w3tc_dashboard' ) ),
+							'dashboardUrl'      => esc_url( network_admin_url( 'admin.php?page=w3tc_dashboard' ) ),
 						),
 					),
 				),
@@ -1386,7 +1386,7 @@ class SetupGuide_Plugin_Admin {
 								'Please visit %1$sGeneral Settings%2$s to learn more about these features.',
 								'w3-total-cache'
 							),
-							'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general' ) ) . '">',
+							'<a href="' . esc_url( network_admin_url( 'admin.php?page=w3tc_general' ) ) . '">',
 							'</a>'
 						) . '</p>
 						<h3>' . esc_html__( 'Need help?', 'w3-total-cache' ) . '</h3>

--- a/SetupGuide_Plugin_Admin.php
+++ b/SetupGuide_Plugin_Admin.php
@@ -40,7 +40,7 @@ class SetupGuide_Plugin_Admin {
 	public function __construct() {
 		$page         = Util_Request::get_string( 'page' );
 		$is_w3tc_ajax = defined( 'DOING_AJAX' ) && DOING_AJAX &&
-			isset( $_POST['action'] ) && 0 === strpos( $_POST['action'], 'w3tc_' );
+			isset( $_POST['action'] ) && 0 === strpos( $_POST['action'], 'w3tc_' ); // phpcs:ignore
 
 		if ( 'w3tc_setup_guide' === $page || $is_w3tc_ajax ) {
 			require_once W3TC_INC_DIR . '/wizard/template.php';
@@ -884,6 +884,7 @@ class SetupGuide_Plugin_Admin {
 		$browsercache_enabled = $config->get_boolean( 'browsercache.enabled' );
 		$page                 = Util_Request::get_string( 'page' );
 		$state                = Dispatcher::config_state();
+		$force_master_config  = $config->get_boolean( 'common.force_master' );
 
 		if ( 'w3tc_extensions' === $page ) {
 			$page = 'extensions/' . Util_Request::get_string( 'extension' );
@@ -934,7 +935,10 @@ class SetupGuide_Plugin_Admin {
 							'disk_enhanced'     => __( 'Disk: Enhanced', 'w3-total-cache' ),
 							'enabled'           => __( 'Enabled', 'w3-total-cache' ),
 							'notEnabled'        => __( 'Not Enabled', 'w3-total-cache' ),
-							'dashboardUrl'      => esc_url( network_admin_url( 'admin.php?page=w3tc_dashboard' ) ),
+							'dashboardUrl'      => esc_url(
+								is_network_admin() ?
+								network_admin_url( 'admin.php?page=w3tc_dashboard' ) : admin_url( 'admin.php?page=w3tc_dashboard' )
+							),
 						),
 					),
 				),
@@ -1386,7 +1390,10 @@ class SetupGuide_Plugin_Admin {
 								'Please visit %1$sGeneral Settings%2$s to learn more about these features.',
 								'w3-total-cache'
 							),
-							'<a href="' . esc_url( network_admin_url( 'admin.php?page=w3tc_general' ) ) . '">',
+							'<a href="' . esc_url(
+								$force_master_config || is_network_admin() ?
+								network_admin_url( 'admin.php?page=w3tc_general' ) : admin_url( 'admin.php?page=w3tc_general' )
+							) . '">',
 							'</a>'
 						) . '</p>
 						<h3>' . esc_html__( 'Need help?', 'w3-total-cache' ) . '</h3>

--- a/SetupGuide_Plugin_Admin.php
+++ b/SetupGuide_Plugin_Admin.php
@@ -935,10 +935,7 @@ class SetupGuide_Plugin_Admin {
 							'disk_enhanced'     => __( 'Disk: Enhanced', 'w3-total-cache' ),
 							'enabled'           => __( 'Enabled', 'w3-total-cache' ),
 							'notEnabled'        => __( 'Not Enabled', 'w3-total-cache' ),
-							'dashboardUrl'      => esc_url(
-								is_network_admin() ?
-								network_admin_url( 'admin.php?page=w3tc_dashboard' ) : admin_url( 'admin.php?page=w3tc_dashboard' )
-							),
+							'dashboardUrl'      => esc_url( Util_Ui::admin_url( 'admin.php?page=w3tc_dashboard' ) ),
 						),
 					),
 				),

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -1044,16 +1044,13 @@ class Util_Ui {
 	}
 
 	/**
+	 * Get the admin URL based on the path and the interface (network or site).
 	 *
-	 *
-	 * @param string  $path
-	 * @return string|void
+	 * @param  string $path Admin path/URI.
+	 * @return string
 	 */
-	static public function admin_url( $path ) {
-		if ( is_network_admin() ) {
-			return network_admin_url( $path );
-		}
-		return admin_url( $path );
+	public static function admin_url( $path ) {
+		return is_network_admin() ? network_admin_url( $path ) : admin_url( $path );
 	}
 
 	/**


### PR DESCRIPTION
The buttons in the Feature Showcase are broken in a multisite installation.  They point to the default blog site instead of the network admin.  There were also a couple of links in the Setup Guide wizard with the same issue.  All were fixed by changing `admin_url()` to `network_admin_url()`, which internally checks for `is_multisite()`.