### PR TITLE
Update UserExperience_LazyLoad_Mutator.php

### DIFF
--- a/UserExperience_LazyLoad_Mutator.php
+++ b/UserExperience_LazyLoad_Mutator.php
@@ -237,8 +237,10 @@ class UserExperience_LazyLoad_Mutator {
 
 	private function is_content_excluded( $content ) {
 		foreach ( $this->excludes as $w ) {
-			if ( strpos( $content, $w ) !== FALSE ) {
-				return true;
+			if ( !empty($w) ) {
+				if ( strpos( $content, $w ) !== FALSE ) {
+					return true;
+				}
 			}
 		}
 


### PR DESCRIPTION
PHP Warning: strpos(): Empty needle in /var/www/vhosts/.../httpdocs/wp-content/plugins/w3-total-cache/UserExperience_LazyLoad_Mutator.php on line 240

Check if the needle in strpos function is empty before searching for it