### PR TITLE
fix hardcoded nginx memcached_pass

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1213,8 +1213,12 @@ class PgCache_Environment {
 		   }
 
 		$rules .= '  default_type text/html;' . "\n";
+
+		$memcached_servers = $config->get_array( 'pgcache.memcached.servers' );
+		$memcached_pass = !empty( $memcached_servers ) ? array_values( $memcached_servers )[0] : 'localhost:11211';
+
 		$rules .= '  if ($w3tc_rewrite = 1) {' . "\n";
-		$rules .= '    memcached_pass localhost:11211;' . "\n";
+		$rules .= '    memcached_pass' . $memcached_pass . ';' . "\n";
 		$rules .= "  }\n";
 		$rules .= '  error_page     404 502 504 = @fallback;' . "\n";
 		$rules .= "}\n";


### PR DESCRIPTION
Resolves #374 

- picks the first server if there
- I tried using the upstream module but unfortunately it requires http context outside the server block. 