### PR TITLE
Prevent redirects coming from wp-cli

### DIFF
--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -191,7 +191,7 @@ class PgCache_Plugin {
 	public function redirect_on_foreign_domain() {
 		$request_host = Util_Environment::host();
 		// host not known, potentially we are in console mode not http request
-		if ( empty( $request_host ) )
+		if ( empty( $request_host ) || defined( 'WP_CLI' ) && WP_CLI )
 			return;
 
 		$home_url = get_home_url();


### PR DESCRIPTION
- checks if wp cli is present and returns
- solution based on my comment https://github.com/W3EDGE/w3-total-cache/issues/305#issuecomment-869040233
- fixes #305