### PR TITLE
Allow use of default AWS credential provider

### DIFF
--- a/CdnEngine_CloudFront.php
+++ b/CdnEngine_CloudFront.php
@@ -30,9 +30,13 @@ class CdnEngine_CloudFront extends CdnEngine_Base {
 			return;
 		}
 
-		$credentials = new \Aws\Credentials\Credentials(
-			$this->_config['key'],
-			$this->_config['secret'] );
+		if ( empty( $this->_config['key'] ) && empty( $this->_config['secret'] ) ) {
+			$credentials = \Aws\Credentials\CredentialProvider::defaultProvider();
+		} else {
+			$credentials = new \Aws\Credentials\Credentials(
+				$this->_config['key'],
+				$this->_config['secret'] );
+		}
 
 		$this->api = new \Aws\CloudFront\CloudFrontClient( array(
 				'credentials' => $credentials,

--- a/CdnEngine_Mirror_CloudFront.php
+++ b/CdnEngine_Mirror_CloudFront.php
@@ -29,9 +29,13 @@ class CdnEngine_Mirror_CloudFront extends CdnEngine_Mirror {
 			return;
 		}
 
-		$credentials = new \Aws\Credentials\Credentials(
-			$this->_config['key'],
-			$this->_config['secret'] );
+		if ( empty( $this->_config['key'] ) && empty( $this->_config['secret'] ) ) {
+			$credentials = \Aws\Credentials\CredentialProvider::defaultProvider();
+		} else {
+			$credentials = new \Aws\Credentials\Credentials(
+				$this->_config['key'],
+				$this->_config['secret'] );
+		}
 
 		$this->api = new \Aws\CloudFront\CloudFrontClient( array(
 				'credentials' => $credentials,

--- a/CdnEngine_S3.php
+++ b/CdnEngine_S3.php
@@ -88,21 +88,25 @@ class CdnEngine_S3 extends CdnEngine_Base {
 			return;
 		}
 
-		if ( empty( $this->_config['key'] ) ) {
-			throw new \Exception( 'Empty access key.' );
-		}
-
-		if ( empty( $this->_config['secret'] ) ) {
-			throw new \Exception( 'Empty secret key.' );
-		}
-
 		if ( empty( $this->_config['bucket'] ) ) {
 			throw new \Exception( 'Empty bucket.' );
 		}
 
-		$credentials = new \Aws\Credentials\Credentials(
-			$this->_config['key'],
-			$this->_config['secret'] );
+		if ( empty( $this->_config['key'] ) && empty( $this->_config['secret'] ) ) {
+			$credentials = \Aws\Credentials\CredentialProvider::defaultProvider();
+		} else {
+			if ( empty( $this->_config['key'] ) ) {
+				throw new \Exception( 'Empty access key.' );
+			}
+
+			if ( empty( $this->_config['secret'] ) ) {
+				throw new \Exception( 'Empty secret key.' );
+			}
+
+			$credentials = new \Aws\Credentials\Credentials(
+				$this->_config['key'],
+				$this->_config['secret'] );
+		}
 
 		$this->api = new \Aws\S3\S3Client( array(
 				'credentials' => $credentials,

--- a/Cdn_RackSpace_Api_Cdn.php
+++ b/Cdn_RackSpace_Api_Cdn.php
@@ -217,7 +217,7 @@ class Cdn_RackSpace_Api_Cdn {
 					'response_json' => array(), 
 					'auth_required' => true 
 				);
-			
+
 			// try to decode response
 			$response_json = @json_decode( $result['body'], true );
 			if ( is_null( $response_json ) ||

--- a/Cdnfsd_CloudFront_Engine.php
+++ b/Cdnfsd_CloudFront_Engine.php
@@ -72,12 +72,24 @@ class Cdnfsd_CloudFront_Engine {
 
 
 	private function _api() {
-		if ( empty( $this->access_key ) || empty( $this->secret_key ) ||
-			empty( $this->distribution_id ) )
-			throw new \Exception( __( 'Access key not specified.', 'w3-total-cache' ) );
+		if ( empty( $this->distribution_id ) ) {
+			throw new \Exception( __('CloudFront distribution not specified.', 'w3-total-cache' ) );
+		}
 
-		$credentials = new \Aws\Credentials\Credentials(
-			$this->access_key, $this->secret_key );
+		if ( empty( $this->access_key ) && empty( $this->secret_key ) ) {
+			$credentials = \Aws\Credentials\CredentialProvider::defaultProvider();
+		} else {
+			if ( empty( $this->access_key ) ) {
+				throw new \Exception( __( 'Access key not specified.', 'w3-total-cache' ) );
+			}
+
+			if ( empty( $this->secret_key ) ) {
+				throw new \Exception( __( 'Secret key not specified.', 'w3-total-cache' ) );
+			}
+
+			$credentials = new \Aws\Credentials\Credentials(
+				$this->access_key, $this->secret_key );
+		}
 
 		return new \Aws\CloudFront\CloudFrontClient( array(
 				'credentials' => $credentials,

--- a/Cdnfsd_CloudFront_Popup.php
+++ b/Cdnfsd_CloudFront_Popup.php
@@ -406,8 +406,12 @@ class Cdnfsd_CloudFront_Popup {
 
 
 	private function _api( $access_key, $secret_key ) {
-		$credentials = new \Aws\Credentials\Credentials(
-			$access_key, $secret_key );
+		if ( empty( $access_key ) && empty( $secret_key ) ) {
+			$credentials = \Aws\Credentials\CredentialProvider::defaultProvider();
+		} else {
+			$credentials = new \Aws\Credentials\Credentials(
+				$access_key, $secret_key );
+		}
 
 		return new \Aws\CloudFront\CloudFrontClient( array(
 				'credentials' => $credentials,

--- a/Enterprise_SnsBase.php
+++ b/Enterprise_SnsBase.php
@@ -34,14 +34,20 @@ class Enterprise_SnsBase {
 	 */
 	protected function _get_api() {
 		if ( is_null( $this->_api ) ) {
-			if ( $this->_api_key == '' )
-				throw new \Exception( 'API Key is not configured' );
-			if ( $this->_api_secret == '' )
-				throw new \Exception( 'API Secret is not configured' );
+			if ( empty( $this->_api_key ) && empty( $this->_api_secret ) ) {
+				$credentials = \Aws\Credentials\CredentialProvider::defaultProvider();
+			} else {
+				if ( empty( $this->_api_key ) ) {
+					throw new \Exception( 'API Key is not configured' );
+				}
 
+				if ( empty( $this->_api_secret ) ) {
+					throw new \Exception( 'API Secret is not configured' );
+				}
 
-			$credentials = new \Aws\Credentials\Credentials(
-				$this->_api_key, $this->_api_secret );
+				$credentials = new \Aws\Credentials\Credentials(
+					$this->_api_key, $this->_api_secret );
+			}
 
 			$this->_api = new \Aws\Sns\SnsClient( array(
 				'credentials' => $credentials,

--- a/Extension_CloudFlare_Plugin.php
+++ b/Extension_CloudFlare_Plugin.php
@@ -134,7 +134,7 @@ class Extension_CloudFlare_Plugin {
 						array( 'cloudflare', 'timelimit.api_request' ) )
 				)
 			);
-			
+
 			try {
 				$api->external_event( 'WP_SPAM', json_encode( $value ) );
 			} catch ( \Exception $ex ) {

--- a/Util_File.php
+++ b/Util_File.php
@@ -335,7 +335,7 @@ class Util_File {
 			if ( !is_dir( W3TC_CACHE_TMP_DIR ) || !is_writable( W3TC_CACHE_TMP_DIR ) ) {
 				$e = error_get_last();
 				$description = ( isset( $e['message'] ) ? $e['message'] : '' );
-				
+
 				throw new \Exception( 'Can\'t create folder <strong>' .
 					W3TC_CACHE_TMP_DIR . '</strong>: ' . $description );
 			}


### PR DESCRIPTION
Resolves #399

If the administrator doesn't configure AWS credentials, fall back to the
default credential provider.  This is especially useful when WordPress
is running within EC2, as the default provider is compatible with the
AWS best practice of manging applications' IAM permissions through
instance profiles instead of hardcoded credentials.