### PR TITLE
determine if response is 404 based on headers as a priority, fixes #42

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -2077,8 +2077,14 @@ class PgCache_ContentGrabber {
 		$compression_of_returned_content =
 			( $has_dynamic ? false : $compression_header );
 
-		$is_404 = ( function_exists( 'is_404' ) ? is_404() : false );
 		$headers = $this->_get_cached_headers( $response_headers['plain'] );
+		if ( !empty( $headers['Status-Code'] ) ) {
+			$is_404 = ( $headers['Status-Code'] == 404 );
+		} elseif ( function_exists( 'is_404' ) ) {
+			$is_404 = is_404();
+		} else {
+			$is_404 = false;
+		}
 
 		if ( $this->_enhanced_mode ) {
 			// redirect issued, if we have some old cache entries


### PR DESCRIPTION
is_404() not always means its really a 404 response.
real behavior may be modified hooks, and opposite.

its more correct to define logic based on real http status response code
(it wasnt available before php54).