### PR TITLE
Fix Setup Guide wizard CSS

### DIFF
--- a/pub/css/setup-guide.css
+++ b/pub/css/setup-guide.css
@@ -20,3 +20,12 @@
 .w3tc-option-recommended {
 	font-size: 0.9em;
 }
+
+#w3tc-options-menu {
+	max-width: 155px;
+}
+
+#w3tc-options-menu li {
+	hyphens: auto;
+	overflow-wrap: break-word;
+}


### PR DESCRIPTION
When the navigation indicator menu on the left in the Setup Guide wizard is translated, longer words were overflowing into the content area.  This fix will break long words using hyphens and wrap the text.
