### PR TITLE
Fix for Redis timeout resulting in 500 error

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -349,21 +349,31 @@ class Cache_Redis extends Cache_Base {
 				$server = $this->_servers[$index];
 				$accessor = new \Redis();
 
+				$config = Dispatcher::config();
+				$pconnect_timeout = $config->get_string( 'redis.pconnect_timeout' );
+				$pconnect_retry_interval = $config->get_string( 'redis.pconnect_retry_interval' );
+				$pconnect_read_timeout = $config->get_string( 'redis.pconnect_read_timeout' );
+				$connect_timeout = $config->get_string( 'redis.connect_timeout' );
+				$connect_retry_interval = $config->get_string( 'redis.connect_retry_interval' );
+				$connect_read_timeout = $config->get_string( 'redis.connect_read_timeout' );
+
 				if ( substr( $server, 0, 5 ) == 'unix:' ) { 
 					if ( $this->_persistent ) {
-						$accessor->pconnect( trim( substr( $server, 5 ) ), null, 1, 
-						    $this->_instance_id . '_' . $this->_dbid, 100, 2 );
+						$accessor->pconnect( trim( substr( $server, 5 ) ), null, $pconnect_timeout, 
+						    $this->_instance_id . '_' . $this->_dbid, $pconnect_retry_interval, $pconnect_read_timeout );
 					} else {
-						$accessor->connect( trim( substr( $server, 5, 1, null, 100, 2 ) ) );
+						$accessor->connect( trim( substr( $server, 5, $connect_timeout, null,
+						    $connect_retry_interval, $connect_read_timeout ) ) );
 					}
 				} else {
 					list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
 
 					if ( $this->_persistent ) {
-						$accessor->pconnect( $ip, $port, 1, 
-						    $this->_instance_id . '_' . $this->_dbid, 100, 2 );
+						$accessor->pconnect( $ip, $port, $pconnect_timeout, 
+						    $this->_instance_id . '_' . $this->_dbid, $pconnect_retry_interval, $pconnect_read_timeout );
 					} else {
-						$accessor->connect( $ip, $port, 1, null, 100, 2 );
+						$accessor->connect( $ip, $port, $connect_timeout, null,
+						    $connect_retry_interval, $connect_read_timeout );
 					}
 				}
 

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -349,21 +349,21 @@ class Cache_Redis extends Cache_Base {
 				$server = $this->_servers[$index];
 				$accessor = new \Redis();
 
-				if ( substr( $server, 0, 5 ) == 'unix:' ) {
+				if ( substr( $server, 0, 5 ) == 'unix:' ) { 
 					if ( $this->_persistent ) {
-						$accessor->pconnect( trim( substr( $server, 5 ) ),
-							null, null, $this->_instance_id . '_' . $this->_dbid );
+						$accessor->pconnect( trim( substr( $server, 5 ) ), null, 1, 
+						    $this->_instance_id . '_' . $this->_dbid, 100, 2 );
 					} else {
-						$accessor->connect( trim( substr( $server, 5 ) ) );
+						$accessor->connect( trim( substr( $server, 5, 1, null, 100, 2 ) ) );
 					}
 				} else {
 					list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
 
 					if ( $this->_persistent ) {
-						$accessor->pconnect( $ip, $port,
-							null, $this->_instance_id . '_' . $this->_dbid );
+						$accessor->pconnect( $ip, $port, 1, 
+						    $this->_instance_id . '_' . $this->_dbid, 100, 2 );
 					} else {
-						$accessor->connect( $ip, $port );
+						$accessor->connect( $ip, $port, 1, null, 100, 2 );
 					}
 				}
 

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -12,6 +12,9 @@ class Cache_Redis extends Cache_Base {
 	private $_password;
 	private $_servers;
 	private $_dbid;
+	private $_timeout;
+	private $_retry_interval;
+	private $_read_timeout;
 
 	/**
 	 * constructor
@@ -25,6 +28,9 @@ class Cache_Redis extends Cache_Base {
 		$this->_servers = (array)$config['servers'];
 		$this->_password = $config['password'];
 		$this->_dbid = $config['dbid'];
+		$this->_timeout = $config['timeout'];
+		$this->_retry_interval = $config['retry_interval'];
+		$this->_read_timeout = $config['read_timeout'];
 
 		// when disabled - no extra requests are made to obtain key version,
 		// but flush operations not supported as a result
@@ -349,31 +355,23 @@ class Cache_Redis extends Cache_Base {
 				$server = $this->_servers[$index];
 				$accessor = new \Redis();
 
-				$config = Dispatcher::config();
-				$pconnect_timeout = $config->get_string( 'redis.pconnect_timeout' );
-				$pconnect_retry_interval = $config->get_string( 'redis.pconnect_retry_interval' );
-				$pconnect_read_timeout = $config->get_string( 'redis.pconnect_read_timeout' );
-				$connect_timeout = $config->get_string( 'redis.connect_timeout' );
-				$connect_retry_interval = $config->get_string( 'redis.connect_retry_interval' );
-				$connect_read_timeout = $config->get_string( 'redis.connect_read_timeout' );
-
 				if ( substr( $server, 0, 5 ) == 'unix:' ) { 
 					if ( $this->_persistent ) {
-						$accessor->pconnect( trim( substr( $server, 5 ) ), null, $pconnect_timeout, 
-						    $this->_instance_id . '_' . $this->_dbid, $pconnect_retry_interval, $pconnect_read_timeout );
+						$accessor->pconnect( trim( substr( $server, 5 ) ), null, $this->_timeout,
+						    $this->_instance_id . '_' . $this->_dbid, $this->_retry_interval, $this->_read_timeout );
 					} else {
-						$accessor->connect( trim( substr( $server, 5, $connect_timeout, null,
-						    $connect_retry_interval, $connect_read_timeout ) ) );
+						$accessor->connect( trim( substr( $server, 5, $this->_timeout, null,
+						    $this->_retry_interval, $this->_read_timeout ) ) );
 					}
 				} else {
 					list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
 
 					if ( $this->_persistent ) {
-						$accessor->pconnect( $ip, $port, $pconnect_timeout, 
-						    $this->_instance_id . '_' . $this->_dbid, $pconnect_retry_interval, $pconnect_read_timeout );
+						$accessor->pconnect( $ip, $port, $this->_timeout,
+						    $this->_instance_id . '_' . $this->_dbid, $this->_retry_interval, $this->_read_timeout );
 					} else {
-						$accessor->connect( $ip, $port, $connect_timeout, null,
-						    $connect_retry_interval, $connect_read_timeout );
+						$accessor->connect( $ip, $port, $this->_timeout, null,
+						    $this->_retry_interval, $this->_read_timeout );
 					}
 				}
 

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -109,6 +109,18 @@ $keys = array(
 		'type' => 'integer',
 		'default' => 0
 	),
+	'dbcache.redis.timeout' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'dbcache.redis.retry_interval' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'dbcache.redis.read_timeout' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
 	'dbcache.use_filters' => array(
 		'type' => 'boolean',
 		'default' => false
@@ -306,6 +318,18 @@ $keys = array(
 		'type' => 'integer',
 		'default' => 0
 	),
+	'objectcache.redis.timeout' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'objectcache.redis.retry_interval' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'objectcache.redis.read_timeout' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
 	'objectcache.groups.global' => array(
 		'type' => 'array',
 		'default' => array(
@@ -419,6 +443,18 @@ $keys = array(
 		'default' => ''
 	),
 	'pgcache.redis.dbid' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'pgcache.redis.timeout' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'pgcache.redis.retry_interval' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'pgcache.redis.read_timeout' => array(
 		'type' => 'integer',
 		'default' => 0
 	),
@@ -789,6 +825,18 @@ $keys = array(
 		'default' => ''
 	),
 	'minify.redis.dbid' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'minify.redis.timeout' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'minify.redis.retry_interval' => array(
+		'type' => 'integer',
+		'default' => 0
+	),
+	'minify.redis.read_timeout' => array(
 		'type' => 'integer',
 		'default' => 0
 	),

--- a/DbCache_Core.php
+++ b/DbCache_Core.php
@@ -25,6 +25,9 @@ class DbCache_Core {
 			$engineConfig = array(
 				'servers' => $c->get_array( 'dbcache.redis.servers' ),
 				'persistent' => $c->get_boolean( 'dbcache.redis.persistent' ),
+				'timeout' => $c->get_integer( 'dbcache.redis.timeout' ),
+				'retry_interval' => $c->get_integer( 'dbcache.redis.retry_interval' ),
+				'read_timeout' => $c->get_integer( 'dbcache.redis.read_timeout' ),
 				'dbid' => $c->get_integer( 'dbcache.redis.dbid' ),
 				'password' => $c->get_string( 'dbcache.redis.password' )
 			);

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -351,6 +351,9 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( 'dbcache.redis.servers' ),
 					'persistent' => $this->_config->get_boolean( 'dbcache.redis.persistent' ),
+					'timeout' => $this->_config->get_integer( 'dbcache.redis.timeout' ),
+					'retry_interval' => $this->_config->get_integer( 'dbcache.redis.retry_interval' ),
+					'read_timeout' => $this->_config->get_integer( 'dbcache.redis.read_timeout' ),
 					'dbid' => $this->_config->get_integer( 'dbcache.redis.dbid' ),
 					'password' => $this->_config->get_string( 'dbcache.redis.password' )
 				);

--- a/Extension_FragmentCache_WpObjectCache.php
+++ b/Extension_FragmentCache_WpObjectCache.php
@@ -481,6 +481,9 @@ class Extension_FragmentCache_WpObjectCache {
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( array( 'fragmentcache', 'redis.servers' ) ),
 					'persistent' => $this->_config->get_boolean( array( 'fragmentcache', 'redis.persistent' ) ),
+					'timeout' => $this->_config->get_integer( array( 'fragmentcache', 'redis.timeout' ) ),
+					'retry_interval' => $this->_config->get_integer( array( 'fragmentcache', 'redis.retry_interval' ) ),
+					'read_timeout' => $this->_config->get_integer( array( 'fragmentcache', 'redis.read_timeout' ) ),
 					'dbid' => $this->_config->get_integer( array( 'fragmentcache', 'redis.dbid' ) ),
 					'password' => $this->_config->get_string( array( 'fragmentcache', 'redis.password' ) )
 				);

--- a/Minify_Core.php
+++ b/Minify_Core.php
@@ -176,6 +176,9 @@ class Minify_Core {
 			$engineConfig = array(
 				'servers' => $c->get_array( 'minify.redis.servers' ),
 				'persistent' => $c->get_boolean( 'minify.redis.persistent' ),
+				'timeout' => $c->get_integer( 'minify.redis.timeout' ),
+				'retry_interval' => $c->get_integer( 'minify.redis.retry_interval' ),
+				'read_timeout' => $c->get_integer( 'minify.redis.read_timeout' ),
 				'dbid' => $c->get_integer( 'minify.redis.dbid' ),
 				'password' => $c->get_string( 'minify.redis.password' )
 			);

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -672,6 +672,9 @@ class Minify_MinifiedFileRequestHandler {
 					'module' => 'minify',
 					'servers' => $this->_config->get_array( 'minify.redis.servers' ),
 					'persistent' => $this->_config->get_boolean( 'minify.redis.persistent' ),
+					'timeout' => $this->_config->get_integer( 'minify.redis.timeout' ),
+					'retry_interval' => $this->_config->get_integer( 'minify.redis.retry_interval' ),
+					'read_timeout' => $this->_config->get_integer( 'minify.redis.read_timeout' ),
 					'dbid' => $this->_config->get_integer( 'minify.redis.dbid' ),
 					'password' => $this->_config->get_string( 'minify.redis.password' )
 				);

--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -697,6 +697,9 @@ class ObjectCache_WpObjectCache_Regular {
 			$engineConfig = array(
 				'servers' => $this->_config->get_array( 'objectcache.redis.servers' ),
 				'persistent' => $this->_config->get_boolean( 'objectcache.redis.persistent' ),
+				'timeout' => $this->_config->get_integer( 'objectcache.redis.timeout' ),
+				'retry_interval' => $this->_config->get_integer( 'objectcache.redis.retry_interval' ),
+				'read_timeout' => $this->_config->get_integer( 'objectcache.redis.read_timeout' ),
 				'dbid' => $this->_config->get_integer( 'objectcache.redis.dbid' ),
 				'password' => $this->_config->get_string( 'objectcache.redis.password' )
 			);
@@ -744,8 +747,10 @@ class ObjectCache_WpObjectCache_Regular {
 			case 'redis':
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( 'objectcache.redis.servers' ),
-					'persistent' => $this->_config->get_boolean(
-						'objectcache.redis.persistent' ),
+					'persistent' => $this->_config->get_boolean( 'objectcache.redis.persistent' ),
+					'timeout' => $this->_config->get_integer( 'objectcache.redis.timeout' ),
+					'retry_interval' => $this->_config->get_integer( 'objectcache.redis.retry_interval' ),
+					'read_timeout' => $this->_config->get_integer( 'objectcache.redis.read_timeout' ),
 					'dbid' => $this->_config->get_integer( 'objectcache.redis.dbid' ),
 					'password' => $this->_config->get_string( 'objectcache.redis.password' )
 				);

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -812,6 +812,9 @@ class PgCache_ContentGrabber {
 			$engineConfig = array(
 				'servers' => $this->_config->get_array( 'pgcache.redis.servers' ),
 				'persistent' => $this->_config->get_boolean( 'pgcache.redis.persistent' ),
+				'timeout' => $this->_config->get_integer( 'pgcache.redis.timeout' ),
+				'retry_interval' => $this->_config->get_integer( 'pgcache.redis.retry_interval' ),
+				'read_timeout' => $this->_config->get_integer( 'pgcache.redis.read_timeout' ),
 				'dbid' => $this->_config->get_integer( 'pgcache.redis.dbid' ),
 				'password' => $this->_config->get_string( 'pgcache.redis.password' )
 			);
@@ -861,6 +864,9 @@ class PgCache_ContentGrabber {
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( 'pgcache.redis.servers' ),
 					'persistent' => $this->_config->get_boolean( 'pgcache.redis.persistent' ),
+					'timeout' => $this->_config->get_integer( 'pgcache.redis.timeout' ),
+					'retry_interval' => $this->_config->get_integer( 'pgcache.redis.retry_interval' ),
+					'read_timeout' => $this->_config->get_integer( 'pgcache.redis.read_timeout' ),
 					'dbid' => $this->_config->get_integer( 'pgcache.redis.dbid' ),
 					'password' => $this->_config->get_string( 'pgcache.redis.password' )
 				);

--- a/Util_ConfigLabel.php
+++ b/Util_ConfigLabel.php
@@ -13,6 +13,9 @@ class Util_ConfigLabel {
 				'memcached.binary_protocol' => __( 'Binary protocol', 'w3-total-cache' ),
 				'redis.servers' => __( 'Redis hostname:port / <acronym title="Internet Protocol">IP</acronym>:port:', 'w3-total-cache' ),
 				'redis.persistent' => __( 'Persistent connection', 'w3-total-cache' ),
+				'redis.timeout' =>  __( 'Connection timeout', 'w3-total-cache' ),
+				'redis.retry_interval' =>  __( 'Connection retry interval', 'w3-total-cache' ),
+				'redis.read_timeout' =>  __( 'Connection read timeout', 'w3-total-cache' ),
 				'redis.dbid' => __( 'Redis Database ID:', 'w3-total-cache' ),
 				'redis.password' => __( 'Redis password:', 'w3-total-cache' ),
 			);

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -31,6 +31,36 @@ if ( !defined( 'W3TC' ) )
 	</td>
 </tr>
 <tr>
+	<th style="width: 250px;"><label for="redis_timeout"><?php echo Util_ConfigLabel::get( 'redis.timeout' ) ?></label></th>
+	<td>
+		<input id="redis_timeout" type="number" name="<?php echo $module ?>__redis__timeout"
+			<?php Util_Ui::sealing_disabled( $module ) ?>
+			value="<?php echo esc_attr( $this->_config->get_integer( $module . '.redis.timeout' ) ); ?>"
+			size="8" step="1" min="0" />
+		<p class="description"><?php _e( 'In seconds', 'w3-total-cache' ); ?></p>
+	</td>
+</tr>
+<tr>
+	<th style="width: 250px;"><label for="redis_retry_interval"><?php echo Util_ConfigLabel::get( 'redis.retry_interval' ) ?></label></th>
+	<td>
+		<input id="redis_retry_interval" type="number" name="<?php echo $module ?>__redis__retry_interval"
+			<?php Util_Ui::sealing_disabled( $module ) ?>
+			value="<?php echo esc_attr( $this->_config->get_integer( $module . '.redis.retry_interval' ) ); ?>"
+			size="8" step="100" min="0" />
+		<p class="description"><?php _e( 'In miliseconds', 'w3-total-cache' ); ?></p>
+	</td>
+</tr>
+<tr>
+	<th style="width: 250px;"><label for="redis_read_timeout"><?php echo Util_ConfigLabel::get( 'redis.read_timeout' ) ?></label></th>
+	<td>
+		<input id="redis_read_timeout" type="number" name="<?php echo $module ?>__redis__read_timeout"
+			<?php Util_Ui::sealing_disabled( $module ) ?>
+			value="<?php echo esc_attr( $this->_config->get_integer( $module . '.redis.read_timeout' ) ); ?>"
+			size="8" step="1" min="0" />
+		<p class="description"><?php _e( 'In seconds', 'w3-total-cache' ); ?></p>
+	</td>
+</tr>
+<tr>
 	<th style="width: 250px;"><label for="redis_dbid"><?php echo Util_ConfigLabel::get( 'redis.dbid' ) ?></label></th>
 	<td>
 		<input id="redis_dbid" type="text" name="<?php echo $module ?>__redis__dbid"

--- a/inc/options/parts/redis_extension.php
+++ b/inc/options/parts/redis_extension.php
@@ -37,6 +37,33 @@ Util_Ui::config_item( array(
 	) );
 
 Util_Ui::config_item( array(
+		'key' => array( $module, 'redis.timeout' ),
+		'label' => Util_ConfigLabel::get( 'redis.timeout' ),
+		'control' => 'textbox',
+		'textbox_type' => 'number',
+		'description' =>
+		__( 'In seconds', 'w3-total-cache' )
+	) );
+
+Util_Ui::config_item( array(
+		'key' => array( $module, 'redis.retry_interval' ),
+		'label' => Util_ConfigLabel::get( 'redis.retry_interval' ),
+		'control' => 'textbox',
+		'textbox_type' => 'number',
+		'description' =>
+		__( 'In miliseconds', 'w3-total-cache' )
+	) );
+
+Util_Ui::config_item( array(
+		'key' => array( $module, 'redis.read_timeout' ),
+		'label' => Util_ConfigLabel::get( 'redis.read_timeout' ),
+		'control' => 'textbox',
+		'textbox_type' => 'number',
+		'description' =>
+		__( 'In seconds', 'w3-total-cache' )
+	) );
+
+Util_Ui::config_item( array(
 		'key' => array( $module, 'redis.dbid' ),
 		'label' => Util_ConfigLabel::get( 'redis.dbid' ),
 		'control' => 'textbox',


### PR DESCRIPTION
Potential fix for server timeout resulting in 500 error if Redis connection/request takes too long to execute for what is allocated by the server