### PR TITLE
Add visibility option.  Fixes #476.

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -2499,6 +2499,7 @@ $keys = array(
 		'default' => array(
 			'compression' => 'lossy',
 			'auto'        => 'enabled',
+			'visibility'  => 'never',
 		),
 	),
 

--- a/Extension_ImageService_Page_View.php
+++ b/Extension_ImageService_Page_View.php
@@ -83,6 +83,23 @@ Util_Ui::config_item(
 		'description'       => esc_html__( 'Auto-convert images on upload.', 'w3-total-cache' ),
 	)
 );
+
+Util_Ui::config_item(
+	array(
+		'key'              => array(
+			'imageservice',
+			'visibility',
+		),
+		'label'            => esc_html__( 'Visibility:', 'w3-total-cache' ),
+		'control'          => 'selectbox',
+		'selectbox_values' => array(
+			'never'     => array( 'label' => __( 'Never', 'w3-total-cache' ) ),
+			'extension' => array( 'label' => __( 'If extension is active', 'w3-total-cache' ) ),
+			'always'    => array( 'label' => __( 'Always', 'w3-total-cache' ) ),
+		),
+		'description'      => esc_html__( 'Show converted image attachments in the Media Library.', 'w3-total-cache' ),
+	)
+);
 ?>
 	</table>
 

--- a/Extension_ImageService_Plugin_Admin.php
+++ b/Extension_ImageService_Plugin_Admin.php
@@ -449,6 +449,10 @@ class Extension_ImageService_Plugin_Admin {
 				$settings['auto'] = sanitize_key( $_POST['imageservice___auto'] );
 			}
 
+			if ( isset( $_POST['imageservice___visibility'] ) ) {
+				$settings['visibility'] = sanitize_key( $_POST['imageservice___visibility'] );
+			}
+
 			$c->set( 'imageservice', $settings );
 			$c->save();
 


### PR DESCRIPTION
An option is added to choose the behavior of hiding converted image attachments via WP_Query filters.  By default, the converted images are never shown, unless the plugin is deactivated.  The new option allows them to be shown all of the time or only when the Image Service extension is active.
