### PR TITLE
PHP 8 Update flush all fatal error Cloudfront

### DIFF
--- a/CdnEngine_Mirror_CloudFront.php
+++ b/CdnEngine_Mirror_CloudFront.php
@@ -110,7 +110,7 @@ class CdnEngine_Mirror_CloudFront extends CdnEngine_Mirror {
 	 * @return bool
 	 */
 	function purge_all( &$results ) {
-		return $this->purge( array( 'remote_path' => '*' ), $results );
+		 return $this->purge( array( array( 'remote_path' => '*' ) ), $results );
 	}
 
 	/**


### PR DESCRIPTION
PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /home/ctmobi/domains/ctmobi.it/public_html/wp-content/plugins/w3-total-cache/CdnEngine_Mirror_CloudFront.php:78