### PR TITLE
Redis: support connecting to servers using TLS with self-signed certificates (e.g., Heroku Redis)

### DIFF
--- a/ConfigCompiler.php
+++ b/ConfigCompiler.php
@@ -418,6 +418,8 @@ class ConfigCompiler {
 			'fragmentcache', 'redis.persistent' );
 		$this->_set_if_exists( $file_data, 'fragmentcache.redis.servers',
 			'fragmentcache', 'redis.servers' );
+		$this->_set_if_exists( $file_data, 'fragmentcache.redis.verify_tls_certificates',
+			'fragmentcache', 'redis.verify_tls_certificates' );
 		$this->_set_if_exists( $file_data, 'fragmentcache.redis.password',
 			'fragmentcache', 'redis.password' );
 		$this->_set_if_exists( $file_data, 'fragmentcache.redis.dbid',

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -101,6 +101,10 @@ $keys = array(
 			'127.0.0.1:6379'
 		)
 	),
+	'dbcache.redis.verify_tls_certificates' => array(
+		'type' => 'boolean',
+		'default' => true
+	),
 	'dbcache.redis.password' => array(
 		'type' => 'string',
 		'default' => ''
@@ -310,6 +314,10 @@ $keys = array(
 			'127.0.0.1:6379'
 		)
 	),
+	'objectcache.redis.verify_tls_certificates' => array(
+		'type' => 'boolean',
+		'default' => true
+	),
 	'objectcache.redis.password' => array(
 		'type' => 'string',
 		'default' => ''
@@ -437,6 +445,10 @@ $keys = array(
 		'default' => array(
 			'127.0.0.1:6379'
 		)
+	),
+	'pgcache.redis.verify_tls_certificates' => array(
+		'type' => 'boolean',
+		'default' => true
 	),
 	'pgcache.redis.password' => array(
 		'type' => 'string',
@@ -819,6 +831,10 @@ $keys = array(
 		'default' => array(
 			'127.0.0.1:6379'
 		)
+	),
+	'minify.redis.verify_tls_certificates' => array(
+		'type' => 'boolean',
+		'default' => true
 	),
 	'minify.redis.password' => array(
 		'type' => 'string',

--- a/DbCache_Core.php
+++ b/DbCache_Core.php
@@ -24,6 +24,7 @@ class DbCache_Core {
 		case 'redis':
 			$engineConfig = array(
 				'servers' => $c->get_array( 'dbcache.redis.servers' ),
+				'verify_tls_certificates' => $c->get_boolean( 'dbcache.redis.verify_tls_certificates' ),
 				'persistent' => $c->get_boolean( 'dbcache.redis.persistent' ),
 				'timeout' => $c->get_integer( 'dbcache.redis.timeout' ),
 				'retry_interval' => $c->get_integer( 'dbcache.redis.retry_interval' ),

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -350,6 +350,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 			case 'redis':
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( 'dbcache.redis.servers' ),
+					'verify_tls_certificates' => $this->_config->get_boolean( 'dbcache.redis.verify_tls_certificates' ),
 					'persistent' => $this->_config->get_boolean( 'dbcache.redis.persistent' ),
 					'timeout' => $this->_config->get_integer( 'dbcache.redis.timeout' ),
 					'retry_interval' => $this->_config->get_integer( 'dbcache.redis.retry_interval' ),

--- a/Extension_FragmentCache_Plugin.php
+++ b/Extension_FragmentCache_Plugin.php
@@ -90,6 +90,7 @@ class Extension_FragmentCache_Plugin {
 			'memcached.persistent' => true,
 			'redis.persistent' => true,
 			'redis.servers' => array( '127.0.0.1:6379' ),
+			'redis.verify_tls_certificates' => true,
 			'lifetime' => 180
 		);
 

--- a/Extension_FragmentCache_WpObjectCache.php
+++ b/Extension_FragmentCache_WpObjectCache.php
@@ -480,6 +480,7 @@ class Extension_FragmentCache_WpObjectCache {
 			case 'redis':
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( array( 'fragmentcache', 'redis.servers' ) ),
+					'verify_tls_certificates' => $this->_config->get_boolean( array( 'fragmentcache', 'redis.verify_tls_certificates' ) ),
 					'persistent' => $this->_config->get_boolean( array( 'fragmentcache', 'redis.persistent' ) ),
 					'timeout' => $this->_config->get_integer( array( 'fragmentcache', 'redis.timeout' ) ),
 					'retry_interval' => $this->_config->get_integer( array( 'fragmentcache', 'redis.retry_interval' ) ),

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -39,6 +39,7 @@ class Generic_AdminActions_Test {
 	 */
 	function w3tc_test_redis() {
 		$servers = Util_Request::get_array( 'servers' );
+		$verify_tls_certificates = Util_Request::get_boolean('verify_tls_certificates', true );
 		$password   = Util_Request::get_string('password', '');
 		$dbid       = Util_Request::get_integer( 'dbid', 0 );
 
@@ -50,6 +51,7 @@ class Generic_AdminActions_Test {
 			foreach ( $servers as $server ) {
 				@$cache = Cache::instance( 'redis', array(
 						'servers' => $server,
+						'verify_tls_certificates' => $verify_tls_certificates,
 						'persistent' => false,
 						'password' => $password,
 						'dbid' => $dbid

--- a/Minify_Core.php
+++ b/Minify_Core.php
@@ -175,6 +175,7 @@ class Minify_Core {
 		case 'redis':
 			$engineConfig = array(
 				'servers' => $c->get_array( 'minify.redis.servers' ),
+				'verify_tls_certificates' => $c->get_boolean( 'minify.redis.verify_tls_certificates' ),
 				'persistent' => $c->get_boolean( 'minify.redis.persistent' ),
 				'timeout' => $c->get_integer( 'minify.redis.timeout' ),
 				'retry_interval' => $c->get_integer( 'minify.redis.retry_interval' ),

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -671,6 +671,7 @@ class Minify_MinifiedFileRequestHandler {
 					'host' =>  Util_Environment::host(),
 					'module' => 'minify',
 					'servers' => $this->_config->get_array( 'minify.redis.servers' ),
+					'verify_tls_certificates' => $this->_config->get_boolean( 'minify.redis.verify_tls_certificates' ),
 					'persistent' => $this->_config->get_boolean( 'minify.redis.persistent' ),
 					'timeout' => $this->_config->get_integer( 'minify.redis.timeout' ),
 					'retry_interval' => $this->_config->get_integer( 'minify.redis.retry_interval' ),

--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -696,6 +696,7 @@ class ObjectCache_WpObjectCache_Regular {
 		case 'redis':
 			$engineConfig = array(
 				'servers' => $this->_config->get_array( 'objectcache.redis.servers' ),
+				'verify_tls_certificates' => $this->_config->get_boolean( 'objectcache.redis.verify_tls_certificates' ),
 				'persistent' => $this->_config->get_boolean( 'objectcache.redis.persistent' ),
 				'timeout' => $this->_config->get_integer( 'objectcache.redis.timeout' ),
 				'retry_interval' => $this->_config->get_integer( 'objectcache.redis.retry_interval' ),
@@ -747,6 +748,7 @@ class ObjectCache_WpObjectCache_Regular {
 			case 'redis':
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( 'objectcache.redis.servers' ),
+					'verify_tls_certificates' => $this->_config->get_boolean( 'objectcache.redis.verify_tls_certificates' ),
 					'persistent' => $this->_config->get_boolean( 'objectcache.redis.persistent' ),
 					'timeout' => $this->_config->get_integer( 'objectcache.redis.timeout' ),
 					'retry_interval' => $this->_config->get_integer( 'objectcache.redis.retry_interval' ),

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -816,6 +816,7 @@ class PgCache_ContentGrabber {
 		case 'redis':
 			$engineConfig = array(
 				'servers' => $this->_config->get_array( 'pgcache.redis.servers' ),
+				'verify_tls_certificates' => $this->_config->get_boolean( 'pgcache.redis.verify_tls_certificates' ),
 				'persistent' => $this->_config->get_boolean( 'pgcache.redis.persistent' ),
 				'timeout' => $this->_config->get_integer( 'pgcache.redis.timeout' ),
 				'retry_interval' => $this->_config->get_integer( 'pgcache.redis.retry_interval' ),
@@ -868,6 +869,7 @@ class PgCache_ContentGrabber {
 			case 'redis':
 				$engineConfig = array(
 					'servers' => $this->_config->get_array( 'pgcache.redis.servers' ),
+					'verify_tls_certificates' => $this->_config->get_boolean( 'pgcache.redis.verify_tls_certificates' ),
 					'persistent' => $this->_config->get_boolean( 'pgcache.redis.persistent' ),
 					'timeout' => $this->_config->get_integer( 'pgcache.redis.timeout' ),
 					'retry_interval' => $this->_config->get_integer( 'pgcache.redis.retry_interval' ),

--- a/Util_ConfigLabel.php
+++ b/Util_ConfigLabel.php
@@ -12,6 +12,7 @@ class Util_ConfigLabel {
 				'memcached.password' => __( 'Memcached password:', 'w3-total-cache' ),
 				'memcached.binary_protocol' => __( 'Binary protocol', 'w3-total-cache' ),
 				'redis.servers' => __( 'Redis hostname:port / <acronym title="Internet Protocol">IP</acronym>:port:', 'w3-total-cache' ),
+				'redis.verify_tls_certificates' => __( 'Verify TLS Certificates', 'w3-total-cache' ),
 				'redis.persistent' => __( 'Persistent connection', 'w3-total-cache' ),
 				'redis.timeout' =>  __( 'Connection timeout', 'w3-total-cache' ),
 				'redis.retry_interval' =>  __( 'Connection retry interval', 'w3-total-cache' ),

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -20,7 +20,7 @@ if ( !defined( 'W3TC' ) )
 			<?php Util_Ui::sealing_disabled( $module ) ?>
 			type="button" value="<?php esc_attr_e( 'Test', 'w3-total-cache' ); ?>" />
 		<span class="w3tc_common_redis_test_result w3tc-status w3tc-process"></span>
-		<p class="description"><?php _e( 'Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:11211, domain.com:22122', 'w3-total-cache' ); ?></p>
+		<p class="description"><?php _e( 'Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:11211, domain.com:22122. To use TLS, prefix server with tls://', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
 <tr>

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -24,6 +24,13 @@ if ( !defined( 'W3TC' ) )
 	</td>
 </tr>
 <tr>
+	<th><label><?php _e( 'Verify TLS Certificates:', 'w3-total-cache' ); ?></label></th>
+	<td>
+		<?php $this->checkbox( $module . '.redis.verify_tls_certificates' ) ?> <?php echo Util_ConfigLabel::get( 'redis.verify_tls_certificates' ) ?></label>
+		<p class="description"><?php _e( 'Verify the server\'s certificate when connecting via TLS.', 'w3-total-cache' ); ?></p>
+	</td>
+</tr>
+<tr>
 	<th><label><?php _e( 'Use persistent connection:', 'w3-total-cache' ); ?></label></th>
 	<td>
 		<?php $this->checkbox( $module . '.redis.persistent' ) ?> <?php echo Util_ConfigLabel::get( 'redis.persistent' ) ?></label>

--- a/inc/options/parts/redis_extension.php
+++ b/inc/options/parts/redis_extension.php
@@ -22,7 +22,7 @@ $config = Dispatcher::config();
 			<?php Util_Ui::sealing_disabled( $module ) ?>
 			type="button" value="<?php esc_attr_e( 'Test', 'w3-total-cache' ); ?>" />
 		<span class="w3tc_common_redis_test_result w3tc-status w3tc-process"></span>
-		<p class="description"><?php _e( 'Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:11211, domain.com:22122', 'w3-total-cache' ); ?></p>
+		<p class="description"><?php _e( 'Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:11211, domain.com:22122. To use TLS, prefix server with tls://', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
 <?php

--- a/inc/options/parts/redis_extension.php
+++ b/inc/options/parts/redis_extension.php
@@ -28,6 +28,15 @@ $config = Dispatcher::config();
 <?php
 
 Util_Ui::config_item( array(
+		'key' => array( $module, 'redis.verify_tls_certificates' ),
+		'label' => Util_ConfigLabel::get( 'redis.verify_tls_certificates' ),
+		'control' => 'checkbox',
+		'checkbox_label' => Util_ConfigLabel::get( 'redis.verify_tls_certificates' ),
+		'description' =>
+		__('Verify the server\'s certificate when connecting via TLS.', 'w3-total-cache')
+	) );
+
+Util_Ui::config_item( array(
 		'key' => array( $module, 'redis.persistent' ),
 		'label' => __( 'Use persistent connection:', 'w3-total-cache' ),
 		'control' => 'checkbox',

--- a/languages/w3-total-cache.pot
+++ b/languages/w3-total-cache.pot
@@ -7585,9 +7585,15 @@ msgstr ""
 msgid "symbols (set to 0 to disable)"
 msgstr ""
 
-#: inc/options/parts/memcached_extension.php:23
-#: inc/options/parts/redis_extension.php:25 inc/options/parts/memcached.php:22
+#: inc/options/parts/redis_extension.php:25
 #: inc/options/parts/redis.php:23
+msgid ""
+"Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:"
+"11211, domain.com:22122. To use TLS, prefix server with tls://"
+msgstr ""
+
+#: inc/options/parts/memcached_extension.php:23
+#: inc/options/parts/memcached.php:22
 msgid ""
 "Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:"
 "11211, domain.com:22122"

--- a/languages/w3-total-cache.pot
+++ b/languages/w3-total-cache.pot
@@ -7674,6 +7674,11 @@ msgstr ""
 
 #: inc/options/parts/redis.php:30
 msgid ""
+"Verify the server\'s certificate when connecting via TLS."
+msgstr ""
+
+#: inc/options/parts/redis.php:37
+msgid ""
 "Using persistent connection doesn't reinitialize redis driver on each request"
 msgstr ""
 

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -969,6 +969,7 @@ jQuery(function() {
 		jQuery.post('admin.php?page=w3tc_dashboard', {
 			w3tc_test_redis: 1,
 			servers: jQuery('#redis_servers').val(),
+			verify_tls_certificates: jQuery('[id$=__redis__verify_tls_certificates]').is(':checked'),
 			dbid : jQuery('#redis_dbid').val(),
 			password : jQuery('#redis_password').val(),
 			_wpnonce: jQuery(this).metadata().nonce


### PR DESCRIPTION
Adds on to https://github.com/W3EDGE/w3-total-cache/issues/67 to include the option of _not_ verifying the redis server's TLS certificate when connecting over TLS.

This option is needed when connecting to a redis server configured to use TLS with self-signed certificates. In particular, [Heroku Redis](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-php) falls under this category.

With this new option TLS certificates continue to be verified by default, but users who need to now have the option of disabling certificate verification.

While working on this, I noticed [this comment from the PR where TLS support was added](https://github.com/W3EDGE/w3-total-cache/issues/67#issuecomment-828548567), so I also updated the UI string to include a hint about how to use redis over TLS.

![](https://c.tenor.com/rsj53iJHx_YAAAAC/superbad-christopher-mintz-plasse.gif)