### PR TITLE
vitrualbox docs say it hardcoded vboxnet for 192.168.56.x

### DIFF
--- a/qa/env/scripts/init-box/templates/Vagrantfile.erb
+++ b/qa/env/scripts/init-box/templates/Vagrantfile.erb
@@ -1,4 +1,4 @@
-ip       = '192.168.100.100'
+ip       = '192.168.56.100'   # check virtualbox vboxnet0 network to match mask
 ram      = '1024'
 
 Vagrant.configure('2') do |config|


### PR DESCRIPTION
now ip is effectively hardcoded, so better to use it

https://www.virtualbox.org/manual/ch06.html#network_hostonly
"On Linux, Mac OS X and Solaris Oracle VM VirtualBox will only allow IP
addresses in 192.168.56.0/21 range to be assigned to host-only
adapters."

other ips still can be used, but needs much more local-env configuration