### PR TITLE
add separate entry for bla and bla/ pages, fixes #250

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -127,6 +127,7 @@ class PgCache_ContentGrabber {
 
 		$this->_request_uri = isset( $_SERVER['REQUEST_URI'] ) ?
 			filter_var( stripslashes( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL ) : ''; // phpcs:ignore
+
 		$this->_lifetime = $this->_config->get_integer( 'pgcache.lifetime' );
 		$this->_late_init = $this->_config->get_boolean( 'pgcache.late_init' );
 		$this->_late_caching = $this->_config->get_boolean( 'pgcache.late_caching' );
@@ -1540,6 +1541,8 @@ class PgCache_ContentGrabber {
 
 		if ( empty( $page_key_extension['group'] ) ) {
 			if ( $this->_enhanced_mode || $this->_nginx_memcached ) {
+				$extra = '';
+
 				// URL decode
 				$key = urldecode( $key );
 
@@ -1553,13 +1556,16 @@ class PgCache_ContentGrabber {
 				$key = preg_replace( '~\?.*$~', '', $key );
 
 				// make sure one slash is at the end
+				if (substr($key, strlen($key) - 1, 1) == '/') {
+					$extra = '_slash';
+				}
 				$key = trim( $key, '/' ) . '/';
 
 				if ( $this->_nginx_memcached ) {
 					return $key;
 				}
 
-				return $key . '_index';
+				return $key . '_index' . $extra;
 			}
 		}
 

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -703,6 +703,10 @@ class PgCache_Environment {
 		$rules .= "    RewriteRule .* - [E=W3TC_PREVIEW:_preview]\n";
 		$env_W3TC_PREVIEW = '%{ENV:W3TC_PREVIEW}';
 
+		$rules .= "    RewriteCond %{REQUEST_URI} \\/$\n";
+		$rules .= "    RewriteRule .* - [E=W3TC_SLASH:_slash]\n";
+		$env_W3TC_SLASH = '%{ENV:W3TC_SLASH}';
+
 		$use_cache_rules = '';
 		/**
 		 * Don't accept POSTs
@@ -735,7 +739,7 @@ class PgCache_Environment {
 		 * Make final rewrites for specific files
 		 */
 		$uri_prefix =  $cache_path . '/%{HTTP_HOST}/%{REQUEST_URI}/' .
-			'_index' . $env_W3TC_UA . $env_W3TC_REF . $env_W3TC_COOKIE .
+			'_index' . $env_W3TC_SLASH . $env_W3TC_UA . $env_W3TC_REF . $env_W3TC_COOKIE .
 			$env_W3TC_SSL . $env_W3TC_PREVIEW;
 		$uri_prefix = apply_filters( 'w3tc_pagecache_rules_apache_uri_prefix',
 			$uri_prefix );
@@ -751,15 +755,6 @@ class PgCache_Environment {
 
 		foreach ( $exts as $ext ) {
 			$rules .= $use_cache_rules;
-
-			if ( $ext == '.html' ) {
-				/**
-				 * Check permalink structure trailing slash
-				 */
-				if ( substr( $permalink_structure, -1 ) == '/' ) {
-					$rules .= "    RewriteCond %{REQUEST_URI} \\/$\n";
-				}
-			}
 
 			$rules .= "    RewriteCond \"" . $document_root . $uri_prefix . $ext .
 				$env_W3TC_ENC . "\"" . $switch . "\n";
@@ -956,17 +951,11 @@ class PgCache_Environment {
 		$rules .= "    set \$w3tc_rewrite 0;\n";
 		$rules .= "}\n";
 
-		/**
-		 * Check permalink structure trailing slash
-		 * and allow WordPress to redirect for non-slash URIs
-		 */
-		if ( $pgcache_engine == 'file_generic' ) {
-			if ( substr( $permalink_structure, -1 ) == '/' ) {
-				$rules .= "if ($env_request_uri !~ \\/$) {\n";
-				$rules .= "    set \$w3tc_rewrite 0;\n";
-				$rules .= "}\n";
-			}
-		}
+		$rules .= "set \$w3tc_slash \"\";\n";
+		$rules .= "if ($env_request_uri ~ \\/$) {\n";
+		$rules .= "    set \$w3tc_slash _slash;\n";
+		$rules .= "}\n";
+		$env_w3tc_slash = "\$w3tc_slash";
 
 		/**
 		 * Check for rejected cookies
@@ -1129,7 +1118,7 @@ class PgCache_Environment {
 			$env_w3tc_enc = '$w3tc_enc';
 		}
 
-		$key_postfix = $env_w3tc_ua . $env_w3tc_ref . $env_w3tc_cookie .
+		$key_postfix = $env_w3tc_slash . $env_w3tc_ua . $env_w3tc_ref . $env_w3tc_cookie .
 			$env_w3tc_ssl . $env_w3tc_preview;
 
 		if ( $pgcache_engine == 'file_generic' ) {

--- a/qa/lib/w3tc.js
+++ b/qa/lib/w3tc.js
@@ -305,18 +305,22 @@ function updateUTimes(filename) {
 exports.pageCacheFileGenericChangeFileTimestamp = async function(url, extension) {
 	log.log("Changing timestamp for the old cache file of " + url);
 	let filename = exports.pageCacheFileGenericUrlToFilename(url, extension);
+	let filenameSlash = exports.pageCacheFileGenericUrlToFilename(url, extension, '_slash');
+	let tryouts = [
+		filename,
+		filename + '_old',
+		filename + '_gzip_old',
+		filenameSlash,
+		filenameSlash + '_old',
+		filenameSlash + '_gzip_old'
+	];
+
 	let someUpdated = false;
-	if (fs.existsSync(filename)) {
-		updateUTimes(filename);
-		someUpdated = true;
-	}
-	if (fs.existsSync(filename + '_old')) {
-		updateUTimes(filename + '_old');
-		someUpdated = true;
-	}
-	if (fs.existsSync(filename + '_gzip_old')) {
-		updateUTimes(filename + '_gzip_old');
-		someUpdated = true;
+	for (let f of tryouts) {
+		if (fs.existsSync(f)) {
+			updateUTimes(f);
+			someUpdated = true;
+		}
 	}
 
 	if (!someUpdated) {
@@ -327,7 +331,7 @@ exports.pageCacheFileGenericChangeFileTimestamp = async function(url, extension)
 
 
 
-exports.pageCacheFileGenericUrlToFilename = function(url, extension) {
+exports.pageCacheFileGenericUrlToFilename = function(url, extension, postfix = '') {
 	if (!extension) {
 		extension = 'html';
 	}
@@ -337,7 +341,9 @@ exports.pageCacheFileGenericUrlToFilename = function(url, extension) {
 	if (uri[uri.length - 1] != '/')
 	uri += '/';
 
-	let cf = (env.scheme == 'https' ? '_index_ssl.' : '_index.') + extension;
+	let cf = '_index' + postfix +
+		(env.scheme == 'https' ? '_ssl' : '') +
+		'.' + extension;
 
 	return env.wpContentPath + 'cache/page_enhanced/' +
 		m[1].toString().toLowerCase() + uri + cf;

--- a/qa/tests/pagecache/trailing-slash.js
+++ b/qa/tests/pagecache/trailing-slash.js
@@ -1,0 +1,128 @@
+function requireRoot(p) {
+	return require('../../' + p);
+}
+
+const expect = require('chai').expect;
+const log = require('mocha-logger');
+
+const env = requireRoot('lib/environment');
+const sys = requireRoot('lib/sys');
+const w3tc = requireRoot('lib/w3tc');
+const wp = requireRoot('lib/wp');
+
+/**environments: environments('blog') */
+
+let testPage;
+
+describe('', function() {
+	this.timeout(sys.suiteTimeout);
+	before(sys.beforeDefault);
+	after(sys.after);
+
+
+
+	it('set options', async() => {
+		await w3tc.setOptions(adminPage, 'w3tc_general', {
+			pgcache__enabled: true,
+			browsercache__enabled: false,
+			pgcache__engine: 'file_generic'
+		});
+
+		await sys.afterRulesChange();
+	});
+
+
+
+	it('create test page', async() => {
+		testPage = await wp.postCreate(adminPage, {
+			type: 'post',
+			title: 'page_1_title',
+			content: 'content1'
+		});
+
+		log.log(testPage.url);
+	});
+
+
+
+	it('fill the cache', async() => {
+		await w3tc.gotoWithPotentialW3TCRepeat(page, env.homeUrl);
+		await w3tc.gotoWithPotentialW3TCRepeat(page, testPage.url);
+		await page.goto(env.homeUrl);
+	});
+
+	it('ends with canoncial for slashed', async() => {
+		let url = testPage.url.replace(/[\/]+$/g, '') + '/';
+		log.log(`trying ${url}`);
+
+		let response = await page.goto(url);
+		expect(page.url()).equals(testPage.url);
+		expectNoPhp(response);
+	});
+
+	it('ends with canoncial for naked', async() => {
+		let url = testPage.url.replace(/[\/]+$/g, '');
+		log.log(`trying ${url}`);
+
+		let response = await page.goto(url);
+		expect(page.url()).equals(testPage.url);
+		expectNoPhp(response);
+	});
+
+	it('updating the post title', async() => {
+		await wp.postUpdate(adminPage, {
+			'post_id'   : testPage.id,
+			'post_title': 'page_2_title',
+			'post_type' : 'post'
+		});
+
+		await w3tc.pageCacheFileGenericChangeFileTimestamp(testPage.url);
+	});
+
+	it('ends with canoncial for slashed', async() => {
+		await page.goto(testPage.url);   // fill the cache
+
+		let url = testPage.url.replace(/[\/]+$/g, '') + '/';
+		log.log(`trying ${url}`);
+
+		let response = await page.goto(url);
+		expect(page.url()).equals(testPage.url);
+		expectNoPhp(response);
+
+		let content = await page.content();
+		expect(content).contains('Page Caching using');
+		log.success('is cached');
+		expect(content).contains('page_2_title');
+		log.success('contains new post content');
+	});
+
+	it('ends with canoncial for naked', async() => {
+		let url = testPage.url.replace(/[\/]+$/g, '');
+		log.log(`trying ${url}`);
+
+		let response = await page.goto(url);
+		expect(page.url()).equals(testPage.url);
+		expectNoPhp(response);
+
+		let content = await page.content();
+		expect(content).contains('Page Caching using');
+		log.success('is cached');
+		expect(content).contains('page_2_title');
+		log.success('contains new post content');
+	});
+});
+
+
+
+function expectNoPhp(response) {
+	log.log('make sure not passed to PHP fallback and handled by rules');
+	let headers = response.headers();
+
+	phpResponse = (headers['w3tc_php'] != null);
+
+	if (env.boxName.indexOf('php55') >= 0) {
+		log.error('php handled here in apache 2.4.7 - skip it since its apache bug');
+	} else {
+		expect(phpResponse).is.false;
+	}
+}


### PR DESCRIPTION
add separate entry for bla and bla/ pages, so that 301 redirects may be issued by wp for variants with/without
slash. that makes google happier