### PR TITLE
fix: DB Cache infinite loop when using `db-cluster-config.php`

### DIFF
--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -539,7 +539,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 			'wp-register',
 		);
 
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		foreach ( $auto_reject_uri as $uri ) {
 			if ( strstr( $request_uri, $uri ) !== false ) {
 				return false;

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -428,7 +428,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 		 */
 		$ajax_skip = false;
 		if ( defined( 'DOING_AJAX' ) ) {
-			$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+			$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_REFERER'] ), FILTER_SANITIZE_URL ) : '';
 			// wp_admin is always defined for ajax requests, check by referrer.
 			if ( strpos( $http_referer, '/wp-admin/' ) === false ) {
 				$ajax_skip = true;
@@ -539,7 +539,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 			'wp-register',
 		);
 
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL ) : '';
 		foreach ( $auto_reject_uri as $uri ) {
 			if ( strstr( $request_uri, $uri ) !== false ) {
 				return false;

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -428,7 +428,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 		 */
 		$ajax_skip = false;
 		if ( defined( 'DOING_AJAX' ) ) {
-			$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+			$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
 			// wp_admin is always defined for ajax requests, check by referrer.
 			if ( strpos( $http_referer, '/wp-admin/' ) === false ) {
 				$ajax_skip = true;
@@ -539,7 +539,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 			'wp-register',
 		);
 
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		foreach ( $auto_reject_uri as $uri ) {
 			if ( strstr( $request_uri, $uri ) !== false ) {
 				return false;

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -428,7 +428,7 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 		 */
 		$ajax_skip = false;
 		if ( defined( 'DOING_AJAX' ) ) {
-			$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+			$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
 			// wp_admin is always defined for ajax requests, check by referrer.
 			if ( strpos( $http_referer, '/wp-admin/' ) === false ) {
 				$ajax_skip = true;


### PR DESCRIPTION
- Fix DB Cache causes infinite loop when using db-cluster-config.php in non-network mode

See: https://github.com/W3EDGE/w3-total-cache/issues/508