### PR TITLE
conflict of wp 5.5 loading="lazy" and w3tc real lazyloading for mobil…

### DIFF
--- a/UserExperience_LazyLoad_Mutator.php
+++ b/UserExperience_LazyLoad_Mutator.php
@@ -103,6 +103,7 @@ class UserExperience_LazyLoad_Mutator {
 				'$1data-$2=', $content );
 
 			$content = $this->add_class_lazy( $content );
+			$content = $this->remove_native_lazy( $content );
 			$this->modified = true;
 		}
 
@@ -218,6 +219,18 @@ class UserExperience_LazyLoad_Mutator {
 		}
 
 		return $content;
+	}
+
+
+
+	/**
+	 * In safari javascript lazy-loaded image with loading="lazy"
+	 * dont fire events, i.e. image not loaded
+	 */
+	public function remove_native_lazy( $content ) {
+		return preg_replace(
+			'~(\s+)loading=[\'"]lazy[\'"]~is', '', $content
+		);
 	}
 
 


### PR DESCRIPTION
…e safari, fixes #501

https://make.wordpress.org/core/2020/07/14/lazy-loading-images-in-5-5/

when there's an img tag with loading="lazy" attribute - it doesnt load
image after src replaced by lazyloading library.
iphone-only issue as usual in last years.

since WP attribute is useless when lazyloader used, seems safe to fix by
blocking wp's loading attribute for images handled by w3tc.