### PR TITLE
make sure no reads or writes are done outside of cache folder

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -203,6 +203,16 @@ class Cache_File_Generic extends Cache_File {
 		if ( !is_readable( $path ) )
 			return null;
 
+		// make sure reading from cache folder
+		// canonicalize to avoid unexpected variants
+		$base_path = realpath( $this->_cache_dir );
+		$path = realpath( $path );
+
+		if ( strlen( $base_path ) <= 0 ||
+				substr( $path, 0, strlen( $base_path ) ) != $base_path ) {
+			return null;
+		}
+
 		$fp = @fopen( $path, 'rb' );
 		if ( !$fp )
 			return null;

--- a/Util_File.php
+++ b/Util_File.php
@@ -93,7 +93,8 @@ class Util_File {
 		$path = trim( $path, '/' );
 		$dirs = explode( '/', $path );
 
-		$curr_path = $from_path;
+		$curr_path = realpath( $from_path );   // use canonicalization
+		$curr_path_previous = $curr_path;
 
 		foreach ( $dirs as $dir ) {
 			if ( $dir == '' )
@@ -104,8 +105,16 @@ class Util_File {
 			$curr_path .= ( $curr_path == '' ? '' : '/' ) . $dir;
 
 			if ( !@file_exists( $curr_path ) ) {
-				if ( !@mkdir( $curr_path, $mask ) )
+				if ( !@mkdir( $curr_path, $mask ) ) {
 					return false;
+				}
+				$curr_path = realpath( $curr_path );
+				// make sure we grow from previous step and dont jump elsewhere
+				if ( strlen( $curr_path ) <= 0 ||
+						substr( $curr_path, 0, strlen( $curr_path_previous ) ) != $curr_path_previous ) {
+					return false;
+				}
+				$curr_path_previous = $curr_path;
 			}
 		}
 


### PR DESCRIPTION
use realpath canonicalzation to make sure no reads or writes are done
outside of cache folder.

realpath-based check is much better for security