### PR TITLE
Avoid PHP warning about pconnect() expecting at most 5 parameters with 6 given on some setups (likely using an older phpredis)

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -474,32 +474,22 @@ class Cache_Redis extends Cache_Base {
 				$server   = $this->_servers[ $index ];
 				$accessor = new \Redis();
 
-				$phpredis_version = phpversion('redis');
-				if ($phpredis_version) {
-					$phpredis_version = (int) $phpredis_version[0]; // Only care about the major version
-				} else {
-					$phpredis_version = 0;
-				}
-				if ($phpredis_version > 4) {
-					$phpredis_modern = true;
-				} else {
-					$phpredis_modern = false;
-				}
+				$phpredis_modern = version_compare( phpversion( 'redis' ), '5', '>=' );
 
 				if ( substr( $server, 0, 5 ) === 'unix:' ) {
 					if ( $this->_persistent ) {
-						if ($phpredis_modern) {
+						if ( $phpredis_modern ) {
 							$accessor->pconnect(
-								trim(substr($server, 5)),
+								trim( substr( $server, 5 ) ),
 								null,
 								$this->_timeout,
 								$this->_instance_id . '_' . $this->_dbid,
 								$this->_retry_interval,
 								$this->_read_timeout
 							);
-						} else { // Old phpredis only supports a subset of parameters
+						} else { // Old phpredis only supports a subset of parameters.
 							$accessor->pconnect(
-								trim(substr($server, 5)),
+								trim( substr( $server, 5 ) ),
 								null,
 								$this->_timeout,
 								$this->_instance_id . '_' . $this->_dbid,
@@ -507,19 +497,28 @@ class Cache_Redis extends Cache_Base {
 							);
 						}
 					} else {
-						$accessor->connect(
-							trim( substr( $server, 5 ) ),
-							$this->_timeout,
-							null,
-							$this->_retry_interval,
-							$this->_read_timeout
-						);
+						if ( $phpredis_modern ) {
+							$accessor->connect(
+								trim( substr( $server, 5 ) ),
+								$this->_timeout,
+								null,
+								$this->_retry_interval,
+								$this->_read_timeout
+							);
+						} else { // Old phpredis only supports a subset of parameters.
+							$accessor->connect(
+								trim( substr( $server, 5 ) ),
+								$this->_timeout,
+								null,
+								$this->_retry_interval
+							);
+						}
 					}
 				} else {
 					list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
 
 					if ( $this->_persistent ) {
-						if ($phpredis_modern) {
+						if ( $phpredis_modern ) {
 							$accessor->pconnect(
 								$ip,
 								$port,
@@ -528,7 +527,7 @@ class Cache_Redis extends Cache_Base {
 								$this->_retry_interval,
 								$this->_read_timeout
 							);
-						} else { // Old phpredis only supports a subset of parameters
+						} else { // Old phpredis only supports a subset of parameters.
 							$accessor->pconnect(
 								$ip,
 								$port,
@@ -538,14 +537,24 @@ class Cache_Redis extends Cache_Base {
 							);
 						}
 					} else {
-						$accessor->connect(
-							$ip,
-							$port,
-							$this->_timeout,
-							null,
-							$this->_retry_interval,
-							$this->_read_timeout
-						);
+						if ( $phpredis_modern ) {
+							$accessor->connect(
+								$ip,
+								$port,
+								$this->_timeout,
+								null,
+								$this->_retry_interval,
+								$this->_read_timeout
+							);
+						} else { // Old phpredis only supports a subset of parameters.
+							$accessor->connect(
+								$ip,
+								$port,
+								$this->_timeout,
+								null,
+								$this->_retry_interval
+							);
+						}
 					}
 
 					restore_error_handler();

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -64,6 +64,10 @@ if ( ! defined( 'W3TC' ) ) {
 		<p class="description"><?php esc_html_e( 'In miliseconds', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
+<?php
+if ( version_compare( phpversion( 'redis' ), '5', '>=' ) ) {
+	// PHP Redis 5 supports the read_timeout setting.
+	?>
 <tr>
 	<th style="width: 250px;"><label for="redis_read_timeout"><?php echo wp_kses( Util_ConfigLabel::get( 'redis.read_timeout' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label></th>
 	<td>
@@ -74,6 +78,9 @@ if ( ! defined( 'W3TC' ) ) {
 		<p class="description"><?php esc_html_e( 'In seconds', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
+	<?php
+}
+?>
 <tr>
 	<th style="width: 250px;"><label for="redis_dbid"><?php echo wp_kses( Util_ConfigLabel::get( 'redis.dbid' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label></th>
 	<td>

--- a/inc/options/parts/redis_extension.php
+++ b/inc/options/parts/redis_extension.php
@@ -74,15 +74,18 @@ Util_Ui::config_item(
 	)
 );
 
-Util_Ui::config_item(
-	array(
-		'key'          => array( $module, 'redis.read_timeout' ),
-		'label'        => Util_ConfigLabel::get( 'redis.read_timeout' ),
-		'control'      => 'textbox',
-		'textbox_type' => 'number',
-		'description'  => __( 'In seconds', 'w3-total-cache' ),
-	)
-);
+if ( version_compare( phpversion( 'redis' ), '5', '>=' ) ) {
+	// PHP Redis 5 supports the read_timeout setting.
+	Util_Ui::config_item(
+		array(
+			'key'          => array( $module, 'redis.read_timeout' ),
+			'label'        => Util_ConfigLabel::get( 'redis.read_timeout' ),
+			'control'      => 'textbox',
+			'textbox_type' => 'number',
+			'description'  => __( 'In seconds', 'w3-total-cache' ),
+		)
+	);
+}
 
 Util_Ui::config_item(
 	array(


### PR DESCRIPTION
I'm currently getting:
```
PHP Warning:  Redis::pconnect() expects at most 5 parameters, 6 given
```
on a server running PHP 7.2 with phpredis 3.1.1 (via php72-pecl-redis).

I'm thinking this is due to phpredis introducing the additional parameters only in later versions. As such, this now version checks for phpredis newer than 4 (so all of v5 and newer) to use what W3TC already had while it reduces the parameters by 1 if it's an older version.

Of course, this can be updated/adapted to be more granular (ex. expand on this to add context support for that specific phpredis version where that support was added) and/or be implemented in a better way overall.

I've also posted this on the WP.org support forums here: https://wordpress.org/support/topic/php-warning-about-pconnect-expecting-at-most-5-parameters-with-6-given/
As well as being a GitHub issue here: https://github.com/W3EDGE/w3-total-cache/issues/533 (just keeping things tied together.)