### PR TITLE
Fix adding max lifetime setting for Page Cache

### DIFF
--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -575,7 +575,7 @@ if ( ! defined( 'W3TC' ) ) {
 					</td>
 				</tr>
 			<?php endif; ?>
-			<?php if ( 'file_generic' === $this->_config->get_string( 'pgcache.engine' ) ) : ?>
+			<?php if ( 'file_generic' !== $this->_config->get_string( 'pgcache.engine' ) ) : ?>
 				<tr>
 					<th><label for="pgcache_lifetime"><?php Util_Ui::e_config_label( 'pgcache.lifetime' ); ?></label></th>
 					<td>


### PR DESCRIPTION
The setting login was reversed in 2.2.2.  See https://github.com/W3EDGE/w3-total-cache/blob/2.2.1/inc/options/pgcache.php#L337 vs https://github.com/W3EDGE/w3-total-cache/blob/2.2.2/inc/options/pgcache.php#L578
