### PR TITLE
fix: moving closing tag to new sprintf() param

### DIFF
--- a/Licensing_Plugin_Admin.php
+++ b/Licensing_Plugin_Admin.php
@@ -204,7 +204,8 @@ class Licensing_Plugin_Admin {
 							'page'                         => 'w3tc_general',
 							'w3tc_licensing_reset_rooturi' => 'y',
 						)
-					) . '"></a>'
+					) . '">',
+					'</a>'
 				),
 				array(
 					'a' => array(


### PR DESCRIPTION
Fixes error:

```
PHP Fatal error:  Uncaught ArgumentCountError: 3 arguments are required, 2 given in /var/www/html/wp-content/plugins/w3-total-cache/Licensing_Plugin_Admin.php:197
2022-07-20T07:54:31.553472336Z Stack trace:
2022-07-20T07:54:31.553475502Z #0 /var/www/html/wp-content/plugins/w3-total-cache/Licensing_Plugin_Admin.php(197): sprintf('The W3 Total Ca...', '<a class="w3tc_...')
2022-07-20T07:54:31.553477669Z #1 /var/www/html/wp-includes/class-wp-hook.php(307): W3TC\Licensing_Plugin_Admin->admin_notices('')
2022-07-20T07:54:31.553479669Z #2 /var/www/html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters(NULL, Array)
2022-07-20T07:54:31.553481377Z #3 /var/www/html/wp-includes/plugin.php(476): WP_Hook->do_action(Array)
2022-07-20T07:54:31.553483044Z #4 /var/www/html/wp-admin/admin-header.php(303): do_action('admin_notices')
2022-07-20T07:54:31.553484669Z #5 /var/www/html/wp-admin/plugins.php(605): require_once('/var/www/html/w...')
2022-07-20T07:54:31.553486294Z #6 {main}
2022-07-20T07:54:31.553488002Z   thrown in /var/www/html/wp-content/plugins/w3-total-cache/Licensing_Plugin_Admin.php on line 197
```