### PR TITLE
Woocommerce Variation Image Gallery plugin CDN fix

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -754,14 +754,14 @@ class Cdn_Plugin {
 	 * @return 	array
 	 */
 	function wp_get_attachment_image_src( $image ) {
-		$url = trim( $image[0] );
+		$url = ( ! emtpy( $image[0] ) ? trim( $image[0] ) : null );
 		
 		if ( ! empty( $url ) ) {
 			$parsed          = parse_url( $url );
 			$uri             = ( isset( $parsed['path'] ) ? $parsed['path'] : '/' ) . ( isset( $parsed['query'] ) ? '?' . $parsed['query'] : '' );
 			$wp_upload_dir   = wp_upload_dir();
 			$upload_base_url = $wp_upload_dir['baseurl'];
-			if ( substr( $url, 0, strlen( $upload_base_url ) ) == $upload_base_url ) {
+			if ( substr( $url, 0, strlen( $upload_base_url ) ) === $upload_base_url ) {
 				$common  = Dispatcher::component( 'Cdn_Core' );
 				$new_url = $common->url_to_cdn_url( $url, $uri );
 				if ( ! is_null( $new_url ) ) {

--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -754,7 +754,7 @@ class Cdn_Plugin {
 	 * @return 	array
 	 */
 	function wp_get_attachment_image_src( $image ) {
-		$url = ( ! emtpy( $image[0] ) ? trim( $image[0] ) : null );
+		$url = empty( $image[0] ) ? null : trim( $image[0] );
 		
 		if ( ! empty( $url ) ) {
 			$parsed          = parse_url( $url );

--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -96,6 +96,9 @@ class Cdn_Plugin {
 		if ( !is_admin() || $this->_config->get_boolean( 'cdn.admin.media_library' ) ) {
 			add_filter( 'wp_prepare_attachment_for_js',
 				array( $this, 'wp_prepare_attachment_for_js' ), 0 );
+
+			add_filter( 'wp_get_attachment_image_src',
+				array( $this, 'wp_get_attachment_image_src' ), 0 );
 		}
 
 		/**
@@ -741,6 +744,33 @@ class Cdn_Plugin {
 		}
 
 		return $url;
+	}
+
+	/**
+	 * Adjusts attachment image src to cdn. This is for those who rely on
+	 * wp_get_attachment_image_src()
+	 *
+	 * @param 	array   $image	Image object
+	 * @return 	array
+	 */
+	function wp_get_attachment_image_src( $image ) {
+		$url = trim( $image[0] );
+		
+		if ( ! empty( $url ) ) {
+			$parsed          = parse_url( $url );
+			$uri             = ( isset( $parsed['path'] ) ? $parsed['path'] : '/' ) . ( isset( $parsed['query'] ) ? '?' . $parsed['query'] : '' );
+			$wp_upload_dir   = wp_upload_dir();
+			$upload_base_url = $wp_upload_dir['baseurl'];
+			if ( substr( $url, 0, strlen( $upload_base_url ) ) == $upload_base_url ) {
+				$common  = Dispatcher::component( 'Cdn_Core' );
+				$new_url = $common->url_to_cdn_url( $url, $uri );
+				if ( ! is_null( $new_url ) ) {
+					$image[0] = $new_url;
+				}
+			}
+		}
+
+		return $image;
 	}
 
 	/**


### PR DESCRIPTION
This fix will apply to any users utilizing W3TC and any plugin/theme that uses wp_get_attachment_image_src with CDN enabled.

You'll need [WooCommerce](https://wordpress.org/plugins/woocommerce/) and [Variation Images Gallery for WooCommerce](https://wordpress.org/plugins/woo-product-variation-gallery/).  You'll also need a variable product.

Once you have WooCommerce and product in place, you should be able to toggle the "Host attachments" setting (on `wp-admin/admin.php?page=w3tc_cdn`) and the product page should serve local/CDN accordingly.  If my fix is working then when "Host attachments" is enabled all product images should be served via the CDN assuming they're uploaded to the bucket.
