### PR TITLE
Redis: reenable support connecting to servers using TLS with self-signed certificates (e.g., Heroku Redis)

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -455,16 +455,16 @@ class Cache_Redis extends Cache_Base {
 	 *
 	 * @param string $server Server URI to connect to.
 	 */
-	private function _build_connect_args($server) {
-		$connect_args = [];
+	private function build_connect_args( $server ) {
+		$connect_args = array();
 
 		if ( substr( $server, 0, 5 ) === 'unix:' ) {
-			$connect_args[] = trim(substr($server, 5));
-			$connect_args[] = null; // port
+			$connect_args[] = trim( substr( $server, 5 ) );
+			$connect_args[] = null; // port.
 		} else {
-			[$ip, $port] = Util_Content::endpoint_to_host_port( $server, null );
-			$connect_args[] = $ip;
-			$connect_args[] = $port;
+			list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
+			$connect_args[]    = $ip;
+			$connect_args[]    = $port;
 		}
 
 		$connect_args[] = $this->_timeout;
@@ -473,19 +473,19 @@ class Cache_Redis extends Cache_Base {
 
 		$phpredis_version = phpversion( 'redis' );
 
-		// the read_timeout parameter was added in phpredis 3.1.3
+		// The read_timeout parameter was added in phpredis 3.1.3.
 		if ( version_compare( $phpredis_version, '3.1.3', '>=' ) ) {
 			$connect_args[] = $this->_read_timeout;
 		}
 
-		// support for stream context was added in phpredis 5.3.2
+		// Support for stream context was added in phpredis 5.3.2.
 		if ( version_compare( $phpredis_version, '5.3.2', '>=' ) ) {
-			$context = [];
-			if ( substr( $server, 0, 4 ) == 'tls:' && !$this->_verify_tls_certificates ) {
-				$context['stream'] = [
-					'verify_peer' => false,
+			$context = array();
+			if ( 'tls:' === substr( $server, 0, 4 ) && ! $this->_verify_tls_certificates ) {
+				$context['stream'] = array(
+					'verify_peer'      => false,
 					'verify_peer_name' => false,
-				];
+				);
 			}
 			$connect_args[] = $context;
 		}
@@ -514,8 +514,8 @@ class Cache_Redis extends Cache_Base {
 			$this->_accessors[ $index ] = null;
 		} else {
 			try {
-				$server = $this->_servers[ $index ];
-				$connect_args = $this->_build_connect_args($server);
+				$server       = $this->_servers[ $index ];
+				$connect_args = $this->build_connect_args( $server );
 
 				$accessor = new \Redis();
 

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -478,6 +478,18 @@ class Cache_Redis extends Cache_Base {
 			$connect_args[] = $this->_read_timeout;
 		}
 
+		// support for stream context was added in phpredis 5.3.2
+		if ( version_compare( $phpredis_version, '5.3.2', '>=' ) ) {
+			$context = [];
+			if ( substr( $server, 0, 4 ) == 'tls:' && !$this->_verify_tls_certificates ) {
+				$context['stream'] = [
+					'verify_peer' => false,
+					'verify_peer_name' => false,
+				];
+			}
+			$connect_args[] = $context;
+		}
+
 		return $connect_args;
 	}
 

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -473,8 +473,8 @@ class Cache_Redis extends Cache_Base {
 
 		$phpredis_version = phpversion( 'redis' );
 
-		// Old phpredis only supports a subset of parameters.
-		if ( version_compare( $phpredis_version, '5', '>=' ) ) {
+		// the read_timeout parameter was added in phpredis 3.1.3
+		if ( version_compare( $phpredis_version, '3.1.3', '>=' ) ) {
 			$connect_args[] = $this->_read_timeout;
 		}
 

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -451,6 +451,37 @@ class Cache_Redis extends Cache_Base {
 	}
 
 	/**
+	 * Build Redis connection arguments based on server URI
+	 *
+	 * @param string $server Server URI to connect to.
+	 */
+	private function _build_connect_args($server) {
+		$connect_args = [];
+
+		if ( substr( $server, 0, 5 ) === 'unix:' ) {
+			$connect_args[] = trim(substr($server, 5));
+			$connect_args[] = null; // port
+		} else {
+			[$ip, $port] = Util_Content::endpoint_to_host_port( $server, null );
+			$connect_args[] = $ip;
+			$connect_args[] = $port;
+		}
+
+		$connect_args[] = $this->_timeout;
+		$connect_args[] = $this->_persistent ? $this->_instance_id . '_' . $this->_dbid : null;
+		$connect_args[] = $this->_retry_interval;
+
+		$phpredis_version = phpversion( 'redis' );
+
+		// Old phpredis only supports a subset of parameters.
+		if ( version_compare( $phpredis_version, '5', '>=' ) ) {
+			$connect_args[] = $this->_read_timeout;
+		}
+
+		return $connect_args;
+	}
+
+	/**
 	 * Get accessor.
 	 *
 	 * @param string $key Key.
@@ -471,91 +502,15 @@ class Cache_Redis extends Cache_Base {
 			$this->_accessors[ $index ] = null;
 		} else {
 			try {
-				$server   = $this->_servers[ $index ];
+				$server = $this->_servers[ $index ];
+				$connect_args = $this->_build_connect_args($server);
+
 				$accessor = new \Redis();
 
-				$phpredis_modern = version_compare( phpversion( 'redis' ), '5', '>=' );
-
-				if ( substr( $server, 0, 5 ) === 'unix:' ) {
-					if ( $this->_persistent ) {
-						if ( $phpredis_modern ) {
-							$accessor->pconnect(
-								trim( substr( $server, 5 ) ),
-								null,
-								$this->_timeout,
-								$this->_instance_id . '_' . $this->_dbid,
-								$this->_retry_interval,
-								$this->_read_timeout
-							);
-						} else { // Old phpredis only supports a subset of parameters.
-							$accessor->pconnect(
-								trim( substr( $server, 5 ) ),
-								null,
-								$this->_timeout,
-								$this->_instance_id . '_' . $this->_dbid,
-								$this->_retry_interval
-							);
-						}
-					} else {
-						if ( $phpredis_modern ) {
-							$accessor->connect(
-								trim( substr( $server, 5 ) ),
-								$this->_timeout,
-								null,
-								$this->_retry_interval,
-								$this->_read_timeout
-							);
-						} else { // Old phpredis only supports a subset of parameters.
-							$accessor->connect(
-								trim( substr( $server, 5 ) ),
-								$this->_timeout,
-								null,
-								$this->_retry_interval
-							);
-						}
-					}
+				if ( $this->_persistent ) {
+					$accessor->pconnect( ...$connect_args );
 				} else {
-					list( $ip, $port ) = Util_Content::endpoint_to_host_port( $server, null );
-
-					if ( $this->_persistent ) {
-						if ( $phpredis_modern ) {
-							$accessor->pconnect(
-								$ip,
-								$port,
-								$this->_timeout,
-								$this->_instance_id . '_' . $this->_dbid,
-								$this->_retry_interval,
-								$this->_read_timeout
-							);
-						} else { // Old phpredis only supports a subset of parameters.
-							$accessor->pconnect(
-								$ip,
-								$port,
-								$this->_timeout,
-								$this->_instance_id . '_' . $this->_dbid,
-								$this->_retry_interval
-							);
-						}
-					} else {
-						if ( $phpredis_modern ) {
-							$accessor->connect(
-								$ip,
-								$port,
-								$this->_timeout,
-								null,
-								$this->_retry_interval,
-								$this->_read_timeout
-							);
-						} else { // Old phpredis only supports a subset of parameters.
-							$accessor->connect(
-								$ip,
-								$port,
-								$this->_timeout,
-								null,
-								$this->_retry_interval
-							);
-						}
-					}
+					$accessor->connect( ...$connect_args );
 				}
 
 				if ( ! empty( $this->_password ) ) {

--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -556,8 +556,6 @@ class Cache_Redis extends Cache_Base {
 							);
 						}
 					}
-
-					restore_error_handler();
 				}
 
 				if ( ! empty( $this->_password ) ) {

--- a/ConfigCache.php
+++ b/ConfigCache.php
@@ -73,6 +73,9 @@ class ConfigCache {
 		case 'redis':
 			$engineConfig = array(
 				'servers' => explode( ',', W3TC_CONFIG_CACHE_REDIS_SERVERS ),
+				'verify_tls_certificates' =>
+					( defined( 'W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES' ) ?
+						W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES : true ),
 				'persistent' =>
 					( defined( 'W3TC_CONFIG_CACHE_REDIS_PERSISTENT' ) ?
 						W3TC_CONFIG_CACHE_REDIS_PERSISTENT : true ),

--- a/ConfigCache.php
+++ b/ConfigCache.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File: ConfigCache.php
+ *
+ * @package W3TC
+ */
+
 namespace W3TC;
 
 /**
@@ -8,8 +14,13 @@ namespace W3TC;
 class ConfigCache {
 	/**
 	 * Reads config from config cache
+	 *
+	 * @param int  $blog_id Blog ID.
+	 * @param bool $preview Preview flag.
+	 *
+	 * @return array|null
 	 */
-	static public function util_array_from_storage( $blog_id, $preview ) {
+	public static function util_array_from_storage( $blog_id, $preview ) {
 		$cache = self::get_cache();
 
 		$config = $cache->get( self::get_key( $blog_id, $preview ) );
@@ -20,101 +31,116 @@ class ConfigCache {
 		return null;
 	}
 
-
-
 	/**
 	 * Removes config cache entry so that it can be read from original source
 	 * on next attempt
+	 *
+	 * @param int  $blog_id Blog ID.
+	 * @param bool $preview Preview flag.
 	 */
-	static public function remove_item( $blog_id, $preview ) {
+	public static function remove_item( $blog_id, $preview ) {
 		$cache = self::get_cache();
 
 		$cache->hard_delete( self::get_key( $blog_id, false ) );
 		$cache->hard_delete( self::get_key( $blog_id, true ) );
 	}
 
-
-
-	static public function save_item( $blog_id, $preview, $data ) {
+	/**
+	 * Saves config cache entry.
+	 *
+	 * @param int   $blog_id Blog ID.
+	 * @param bool  $preview Preview flag.
+	 * @param mixed $data Data.
+	 */
+	public static function save_item( $blog_id, $preview, $data ) {
 		$cache = self::get_cache();
 
 		$cache->set( self::get_key( $blog_id, $preview ), $data );
 	}
 
-
-
-	static private function get_cache() {
+	/**
+	 * Retrieves cache instance.
+	 *
+	 * @return object
+	 */
+	private static function get_cache() {
 		static $cache = null;
 
-		if ( !is_null( $cache ) ) {
+		if ( ! is_null( $cache ) ) {
 			return $cache;
 		}
 
 		switch ( W3TC_CONFIG_CACHE_ENGINE ) {
-		case 'memcached':
-			$engineConfig = array(
-				'servers' => explode( ',', W3TC_CONFIG_CACHE_MEMCACHED_SERVERS ),
-				'persistent' =>
-					( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_PERSISTENT' ) ?
-						W3TC_CONFIG_CACHE_MEMCACHED_PERSISTENT : true ),
-				'aws_autodiscovery' =>
-					( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_AWS_AUTODISCOVERY' ) ?
-						W3TC_CONFIG_CACHE_MEMCACHED_AWS_AUTODISCOVERY : false ),
-				'username' =>
-					( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_USERNAME' ) ?
-						W3TC_CONFIG_CACHE_MEMCACHED_USERNAME : '' ),
-				'password' =>
-					( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_PASSWORD' ) ?
-						W3TC_CONFIG_CACHE_MEMCACHED_PASSWORD : '' ),
-				'key_version_mode' => 'disabled'
-			);
-			break;
-
-		case 'redis':
-			$engineConfig = array(
-				'servers' => explode( ',', W3TC_CONFIG_CACHE_REDIS_SERVERS ),
-				'verify_tls_certificates' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES' ) ?
-						W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES : true ),
-				'persistent' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_PERSISTENT' ) ?
-						W3TC_CONFIG_CACHE_REDIS_PERSISTENT : true ),
-				'dbid' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_DBID' ) ?
-						W3TC_CONFIG_CACHE_REDIS_DBID : 0 ),
-				'password' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_PASSWORD' ) ?
-						W3TC_CONFIG_CACHE_REDIS_PASSWORD : '' ),
-				'timeout' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_TIMEOUT' ) ?
-						W3TC_CONFIG_CACHE_REDIS_TIMEOUT : 0 ),
-				'retry_interval' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_RETRY_INTERVAL' ) ?
-						W3TC_CONFIG_CACHE_REDIS_RETRY_INTERVAL : 0 ),
-				'read_timeout' =>
-					( defined( 'W3TC_CONFIG_CACHE_REDIS_READ_TIMEOUT' ) ?
-						W3TC_CONFIG_CACHE_REDIS_READ_TIMEOUT : 0 ),
-				'key_version_mode' => 'disabled'
-			);
-			break;
-
-		default:
-			$engineConfig = array();
+			case 'memcached':
+				$engine_config = array(
+					'servers'           =>
+						explode( ',', W3TC_CONFIG_CACHE_MEMCACHED_SERVERS ),
+					'persistent'        =>
+						( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_PERSISTENT' ) ?
+							W3TC_CONFIG_CACHE_MEMCACHED_PERSISTENT : true ),
+					'aws_autodiscovery' =>
+						( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_AWS_AUTODISCOVERY' ) ?
+							W3TC_CONFIG_CACHE_MEMCACHED_AWS_AUTODISCOVERY : false ),
+					'username'          =>
+						( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_USERNAME' ) ?
+							W3TC_CONFIG_CACHE_MEMCACHED_USERNAME : '' ),
+					'password'          =>
+						( defined( 'W3TC_CONFIG_CACHE_MEMCACHED_PASSWORD' ) ?
+							W3TC_CONFIG_CACHE_MEMCACHED_PASSWORD : '' ),
+					'key_version_mode'  => 'disabled',
+				);
+				break;
+			case 'redis':
+				$engine_config = array(
+					'servers'                 =>
+						explode( ',', W3TC_CONFIG_CACHE_REDIS_SERVERS ),
+					'verify_tls_certificates' =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES' ) ?
+							W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES : true ),
+					'persistent'              =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_PERSISTENT' ) ?
+							W3TC_CONFIG_CACHE_REDIS_PERSISTENT : true ),
+					'dbid'                    =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_DBID' ) ?
+							W3TC_CONFIG_CACHE_REDIS_DBID : 0 ),
+					'password'                =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_PASSWORD' ) ?
+							W3TC_CONFIG_CACHE_REDIS_PASSWORD : '' ),
+					'timeout'                 =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_TIMEOUT' ) ?
+							W3TC_CONFIG_CACHE_REDIS_TIMEOUT : 0 ),
+					'retry_interval'          =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_RETRY_INTERVAL' ) ?
+							W3TC_CONFIG_CACHE_REDIS_RETRY_INTERVAL : 0 ),
+					'read_timeout'            =>
+						( defined( 'W3TC_CONFIG_CACHE_REDIS_READ_TIMEOUT' ) ?
+							W3TC_CONFIG_CACHE_REDIS_READ_TIMEOUT : 0 ),
+					'key_version_mode'        => 'disabled',
+				);
+				break;
+			default:
+				$engine_config = array();
 		}
 
-		$engineConfig['blog_id'] = '0';
-		$engineConfig['module'] = 'config';
-		$engineConfig['host'] = '';
-		$engineConfig['instance_id'] =
-			( defined( 'W3TC_INSTANCE_ID' ) ? W3TC_INSTANCE_ID : 0 );
+		$engine_config['blog_id']     = '0';
+		$engine_config['module']      = 'config';
+		$engine_config['host']        = '';
+		$engine_config['instance_id'] = ( defined( 'W3TC_INSTANCE_ID' ) ? W3TC_INSTANCE_ID : 0 );
 
-		$cache = Cache::instance( W3TC_CONFIG_CACHE_ENGINE, $engineConfig );
+		$cache = Cache::instance( W3TC_CONFIG_CACHE_ENGINE, $engine_config );
+
 		return $cache;
 	}
 
-
-
-	static private function get_key( $blog_id, $preview ) {
+	/**
+	 * Retrieves config cache key.
+	 *
+	 * @param int  $blog_id Blog ID.
+	 * @param bool $preview Preview flag.
+	 *
+	 * @return string
+	 */
+	private static function get_key( $blog_id, $preview ) {
 		return 'w3tc_config_' . $blog_id . ( $preview ? '_preview' : '' );
 	}
 }

--- a/DbCache_Plugin.php
+++ b/DbCache_Plugin.php
@@ -242,29 +242,34 @@ class DbCache_Plugin {
 			) );
 	}
 
-
-
+	/**
+	 * Usage Statisitcs sources filter.
+	 *
+	 * @param array $sources Sources.
+	 *
+	 * @return array
+	 */
 	public function w3tc_usage_statistics_sources( $sources ) {
 		$c = Dispatcher::config();
-		if ( $c->get_string( 'dbcache.engine' ) == 'apc' ) {
+		if ( 'apc' === $c->get_string( 'dbcache.engine' ) ) {
 			$sources['apc_servers']['dbcache'] = array(
-				'name' => __( 'Database Cache', 'w3-total-cache' )
+				'name' => __( 'Database Cache', 'w3-total-cache' ),
 			);
-		} elseif ( $c->get_string( 'dbcache.engine' ) == 'memcached' ) {
+		} elseif ( 'memcached' === $c->get_string( 'dbcache.engine' ) ) {
 			$sources['memcached_servers']['dbcache'] = array(
-				'servers' => $c->get_array( 'dbcache.memcached.servers' ),
+				'servers'  => $c->get_array( 'dbcache.memcached.servers' ),
 				'username' => $c->get_string( 'dbcache.memcached.username' ),
 				'password' => $c->get_string( 'dbcache.memcached.password' ),
-				'name' => __( 'Database Cache', 'w3-total-cache' )
+				'name'     => __( 'Database Cache', 'w3-total-cache' ),
 			);
-		} elseif ( $c->get_string( 'dbcache.engine' ) == 'redis' ) {
+		} elseif ( 'redis' === $c->get_string( 'dbcache.engine' ) ) {
 			$sources['redis_servers']['dbcache'] = array(
-				'servers' => $c->get_array( 'dbcache.redis.servers' ),
+				'servers'                 => $c->get_array( 'dbcache.redis.servers' ),
 				'verify_tls_certificates' => $c->get_boolean( 'dbcache.redis.verify_tls_certificates' ),
-				'username' => $c->get_boolean( 'dbcache.redis.username' ),
-				'dbid' => $c->get_integer( 'dbcache.redis.dbid' ),
-				'password' => $c->get_string( 'dbcache.redis.password' ),
-				'name' => __( 'Database Cache', 'w3-total-cache' )
+				'username'                => $c->get_boolean( 'dbcache.redis.username' ),
+				'dbid'                    => $c->get_integer( 'dbcache.redis.dbid' ),
+				'password'                => $c->get_string( 'dbcache.redis.password' ),
+				'name'                    => __( 'Database Cache', 'w3-total-cache' ),
 			);
 		}
 

--- a/DbCache_Plugin.php
+++ b/DbCache_Plugin.php
@@ -260,6 +260,7 @@ class DbCache_Plugin {
 		} elseif ( $c->get_string( 'dbcache.engine' ) == 'redis' ) {
 			$sources['redis_servers']['dbcache'] = array(
 				'servers' => $c->get_array( 'dbcache.redis.servers' ),
+				'verify_tls_certificates' => $c->get_boolean( 'dbcache.redis.verify_tls_certificates' ),
 				'username' => $c->get_boolean( 'dbcache.redis.username' ),
 				'dbid' => $c->get_integer( 'dbcache.redis.dbid' ),
 				'password' => $c->get_string( 'dbcache.redis.password' ),

--- a/DbCache_Plugin.php
+++ b/DbCache_Plugin.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * File: DbCache_Plugin.php
+ *
+ * @package W3TC
+ *
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+ */
+
 namespace W3TC;
 
 /**
@@ -6,110 +14,53 @@ namespace W3TC;
  */
 class DbCache_Plugin {
 	/**
-	 * Config
+	 * Config.
+	 *
+	 * @var array
 	 */
 	private $_config = null;
 
-	function __construct() {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
 		$this->_config = Dispatcher::config();
 	}
 
 	/**
 	 * Runs plugin
 	 */
-	function run() {
-		add_filter( 'cron_schedules', array(
-				$this,
-				'cron_schedules'
-			) );
+	public function run() {
+		// phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
+		add_filter( 'cron_schedules', array( $this, 'cron_schedules' ) );
 
-		if ( $this->_config->get_string( 'dbcache.engine' ) == 'file' ) {
-			add_action( 'w3_dbcache_cleanup', array(
-					$this,
-					'cleanup'
-				) );
+		if ( 'file' === $this->_config->get_string( 'dbcache.engine' ) ) {
+			add_action( 'w3_dbcache_cleanup', array( $this, 'cleanup' ) );
 		}
 
-		add_action( 'publish_phone', array(
-				$this,
-				'on_change'
-			), 0 );
-
-		add_action( 'wp_trash_post', array(
-				$this,
-				'on_post_change'
-			), 0 );
-
-		add_action( 'save_post', array(
-				$this,
-				'on_post_change'
-			), 0 );
-
-		add_action( 'clean_post_cache', array(
-				$this,
-				'on_post_change'
-			), 0, 2 );
-
-		add_action( 'comment_post', array(
-				$this,
-				'on_comment_change'
-			), 0 );
-
-		add_action( 'edit_comment', array(
-				$this,
-				'on_comment_change'
-			), 0 );
-
-		add_action( 'delete_comment', array(
-				$this,
-				'on_comment_change'
-			), 0 );
-
-		add_action( 'wp_set_comment_status', array(
-				$this,
-				'on_comment_status'
-			), 0, 2 );
-
-		add_action( 'trackback_post', array(
-				$this,
-				'on_comment_change'
-			), 0 );
-
-		add_action( 'pingback_post', array(
-				$this,
-				'on_comment_change'
-			), 0 );
-
-		add_action( 'switch_theme', array(
-				$this,
-				'on_change'
-			), 0 );
-
-		add_action( 'edit_user_profile_update', array(
-				$this,
-				'on_change'
-			), 0 );
+		add_action( 'publish_phone', array( $this, 'on_change' ), 0 );
+		add_action( 'wp_trash_post', array( $this, 'on_post_change' ), 0 );
+		add_action( 'save_post', array( $this, 'on_post_change' ), 0 );
+		add_action( 'clean_post_cache', array( $this, 'on_post_change' ), 0, 2 );
+		add_action( 'comment_post', array( $this, 'on_comment_change' ), 0 );
+		add_action( 'edit_comment', array( $this, 'on_comment_change' ), 0 );
+		add_action( 'delete_comment', array( $this, 'on_comment_change' ), 0 );
+		add_action( 'wp_set_comment_status', array( $this, 'on_comment_status' ), 0, 2 );
+		add_action( 'trackback_post', array( $this, 'on_comment_change' ), 0 );
+		add_action( 'pingback_post', array( $this, 'on_comment_change' ), 0 );
+		add_action( 'switch_theme', array( $this, 'on_change' ), 0 );
+		add_action( 'edit_user_profile_update', array( $this, 'on_change' ), 0 );
+		add_action( 'delete_post', array( $this, 'on_post_change' ), 0 );
 
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'delete_blog', array(
-					$this,
-					'on_change'
-				), 0 );
+			add_action( 'delete_blog', array( $this, 'on_change' ), 0 );
 		}
 
-		add_action( 'delete_post', array(
-				$this,
-				'on_post_change'
-			), 0 );
+		add_filter( 'w3tc_admin_bar_menu', array( $this, 'w3tc_admin_bar_menu' ) );
 
-		add_filter( 'w3tc_admin_bar_menu',
-			array( $this, 'w3tc_admin_bar_menu' ) );
-
-		// usage statistics handling
-		add_filter( 'w3tc_usage_statistics_metrics', array(
-				$this, 'w3tc_usage_statistics_metrics' ) );
-		add_filter( 'w3tc_usage_statistics_sources', array(
-				$this, 'w3tc_usage_statistics_sources' ) );
+		// usage statistics handling.
+		add_filter( 'w3tc_usage_statistics_metrics', array( $this, 'w3tc_usage_statistics_metrics' ) );
+		add_filter( 'w3tc_usage_statistics_sources', array( $this, 'w3tc_usage_statistics_sources' ) );
 	}
 
 	/**
@@ -117,11 +68,13 @@ class DbCache_Plugin {
 	 *
 	 * @return void
 	 */
-	function cleanup() {
-		$w3_cache_file_cleaner = new Cache_File_Cleaner( array(
-				'cache_dir' => Util_Environment::cache_blog_dir( 'db' ),
-				'clean_timelimit' => $this->_config->get_integer( 'timelimit.cache_gc' )
-			) );
+	public function cleanup() {
+		$w3_cache_file_cleaner = new Cache_File_Cleaner(
+			array(
+				'cache_dir'       => Util_Environment::cache_blog_dir( 'db' ),
+				'clean_timelimit' => $this->_config->get_integer( 'timelimit.cache_gc' ),
+			)
+		);
 
 		$w3_cache_file_cleaner->clean();
 	}
@@ -129,27 +82,35 @@ class DbCache_Plugin {
 	/**
 	 * Cron schedules filter
 	 *
-	 * @param array   $schedules
+	 * @param array $schedules Schedules.
+	 *
 	 * @return array
 	 */
-	function cron_schedules( $schedules ) {
+	public function cron_schedules( $schedules ) {
 		$gc = $this->_config->get_integer( 'dbcache.file.gc' );
 
-		return array_merge( $schedules, array(
+		return array_merge(
+			$schedules,
+			array(
 				'w3_dbcache_cleanup' => array(
 					'interval' => $gc,
-					'display' => sprintf( '[W3TC] Database Cache file GC (every %d seconds)', $gc )
-				)
-			) );
+					'display'  => sprintf(
+						// translators: 1 interval in seconds.
+						__( '[W3TC] Database Cache file GC (every %d seconds)', 'w3-total-cache' ),
+						$gc
+					),
+				),
+			)
+		);
 	}
 
 	/**
 	 * Change action
 	 */
-	function on_change() {
+	public function on_change() {
 		static $flushed = false;
 
-		if ( !$flushed ) {
+		if ( ! $flushed ) {
 			$flusher = Dispatcher::component( 'CacheFlush' );
 			$flusher->dbcache_flush();
 
@@ -159,18 +120,19 @@ class DbCache_Plugin {
 
 	/**
 	 * Change post action
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param mixed $post Post.
 	 */
-	function on_post_change( $post_id = 0, $post = null ) {
+	public function on_post_change( $post_id = 0, $post = null ) {
 		static $flushed = false;
 
-		if ( !$flushed ) {
+		if ( ! $flushed ) {
 			if ( is_null( $post ) ) {
 				$post = $post_id;
 			}
 
-			if ( $post_id > 0 &&
-					!Util_Environment::is_flushable_post(
-						$post, 'dbcache', $this->_config ) ) {
+			if ( $post_id > 0 && ! Util_Environment::is_flushable_post( $post, 'dbcache', $this->_config ) ) {
 				return;
 			}
 
@@ -184,14 +146,14 @@ class DbCache_Plugin {
 	/**
 	 * Comment change action
 	 *
-	 * @param integer $comment_id
+	 * @param integer $comment_id Comment ID.
 	 */
-	function on_comment_change( $comment_id ) {
+	public function on_comment_change( $comment_id ) {
 		$post_id = 0;
 
 		if ( $comment_id ) {
 			$comment = get_comment( $comment_id, ARRAY_A );
-			$post_id = !empty( $comment['comment_post_ID'] ) ? (int) $comment['comment_post_ID'] : 0;
+			$post_id = ! empty( $comment['comment_post_ID'] ) ? (int) $comment['comment_post_ID'] : 0;
 		}
 
 		$this->on_post_change( $post_id );
@@ -200,46 +162,59 @@ class DbCache_Plugin {
 	/**
 	 * Comment status action
 	 *
-	 * @param integer $comment_id
-	 * @param string  $status
+	 * @param integer $comment_id Comment ID.
+	 * @param string  $status Status.
 	 */
-	function on_comment_status( $comment_id, $status ) {
-		if ( $status === 'approve' || $status === '1' ) {
+	public function on_comment_status( $comment_id, $status ) {
+		if ( 'approve' === $status || '1' === $status ) {
 			$this->on_comment_change( $comment_id );
 		}
 	}
 
-
-
+	/**
+	 * Setup admin menu elements
+	 *
+	 * @param array $menu_items Menu items.
+	 */
 	public function w3tc_admin_bar_menu( $menu_items ) {
 		$menu_items['20310.dbcache'] = array(
-			'id' => 'w3tc_flush_dbcache',
+			'id'     => 'w3tc_flush_dbcache',
 			'parent' => 'w3tc_flush',
-			'title' => __( 'Database', 'w3-total-cache' ),
-			'href' => wp_nonce_url( admin_url(
-					'admin.php?page=w3tc_dashboard&amp;w3tc_flush_dbcache' ),
-				'w3tc' )
+			'title'  => __( 'Database', 'w3-total-cache' ),
+			'href'   => wp_nonce_url(
+				admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_dbcache' ),
+				'w3tc'
+			),
 		);
 
 		return $menu_items;
 	}
 
-
-
+	/**
+	 * Usage statistics of request filter
+	 *
+	 * @param object $storage Storage object.
+	 */
 	public function w3tc_usage_statistics_of_request( $storage ) {
 		$o = Dispatcher::component( 'ObjectCache_WpObjectCache_Regular' );
 		$o->w3tc_usage_statistics_of_request( $storage );
 	}
 
-
-
+	/**
+	 * Retrive usage statistics metrics
+	 *
+	 * @param array $metrics Metrics.
+	 */
 	public function w3tc_usage_statistics_metrics( $metrics ) {
-		return array_merge( $metrics, array(
+		return array_merge(
+			$metrics,
+			array(
 				'dbcache_calls_total',
 				'dbcache_calls_hits',
 				'dbcache_flushes',
-				'dbcache_time_ms'
-			) );
+				'dbcache_time_ms',
+			)
+		);
 	}
 
 	/**

--- a/ObjectCache_Plugin.php
+++ b/ObjectCache_Plugin.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * File: ObjectCache_Plugin.php
+ *
+ * @package W3TC
+ *
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+ */
+
 namespace W3TC;
 
 /**
@@ -6,122 +14,65 @@ namespace W3TC;
  */
 class ObjectCache_Plugin {
 	/**
-	 * Config
+	 * Config.
+	 *
+	 * @var array
 	 */
 	private $_config = null;
 
-	function __construct() {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
 		$this->_config = Dispatcher::config();
 	}
 
 	/**
 	 * Runs plugin
 	 */
-	function run() {
-		add_filter( 'cron_schedules', array(
-				$this,
-				'cron_schedules'
-			) );
+	public function run() {
+		// phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
+		add_filter( 'cron_schedules', array( $this, 'cron_schedules' ) );
 
-		add_filter( 'w3tc_footer_comment', array(
-				$this,
-				'w3tc_footer_comment'
-			) );
+		add_filter( 'w3tc_footer_comment', array( $this, 'w3tc_footer_comment' ) );
 
-		if ( $this->_config->get_string( 'objectcache.engine' ) == 'file' ) {
-			add_action( 'w3_objectcache_cleanup', array(
-					$this,
-					'cleanup'
-				) );
+		if ( 'file' === $this->_config->get_string( 'objectcache.engine' ) ) {
+			add_action( 'w3_objectcache_cleanup', array( $this, 'cleanup' ) );
 		}
 
 		if ( $this->_do_flush() ) {
-			add_action( 'clean_post_cache', array(
-					$this,
-					'on_post_change'
-				), 0, 2 );
+			add_action( 'clean_post_cache', array( $this, 'on_post_change' ), 0, 2 );
 		}
 
 		if ( $this->_do_flush() ) {
-			add_action( 'comment_post', array(
-					$this,
-					'on_comment_change'
-				), 0 );
-
-			add_action( 'edit_comment', array(
-					$this,
-					'on_comment_change'
-				), 0 );
-
-			add_action( 'delete_comment', array(
-					$this,
-					'on_comment_change'
-				), 0 );
-
-			add_action( 'wp_set_comment_status', array(
-					$this,
-					'on_comment_status'
-				), 0, 2 );
-
-			add_action( 'trackback_post', array(
-					$this,
-					'on_comment_change'
-				), 0 );
-
-			add_action( 'pingback_post', array(
-					$this,
-					'on_comment_change'
-				), 0 );
+			add_action( 'comment_post', array( $this, 'on_comment_change' ), 0 );
+			add_action( 'edit_comment', array( $this, 'on_comment_change' ), 0 );
+			add_action( 'delete_comment', array( $this, 'on_comment_change' ), 0 );
+			add_action( 'wp_set_comment_status', array( $this, 'on_comment_status' ), 0, 2 );
+			add_action( 'trackback_post', array( $this, 'on_comment_change' ), 0 );
+			add_action( 'pingback_post', array( $this, 'on_comment_change' ), 0 );
 		}
 
-		add_action( 'switch_theme', array(
-				$this,
-				'on_change'
-			), 0 );
+		add_action( 'switch_theme', array( $this, 'on_change' ), 0 );
 
 		if ( $this->_do_flush() ) {
-			add_action( 'updated_option', array(
-					$this,
-					'on_change_option'
-				), 0, 1 );
-			add_action( 'added_option', array(
-					$this,
-					'on_change_option'
-				), 0, 1 );
-
-			add_action( 'delete_option', array(
-					$this,
-					'on_change_option'
-				), 0, 1 );
+			add_action( 'updated_option', array( $this, 'on_change_option' ), 0, 1 );
+			add_action( 'added_option', array( $this, 'on_change_option' ), 0, 1 );
+			add_action( 'delete_option', array( $this, 'on_change_option' ), 0, 1 );
 		}
 
-		add_action( 'edit_user_profile_update', array(
-				$this,
-				'on_change_profile'
-			), 0 );
+		add_action( 'edit_user_profile_update', array( $this, 'on_change_profile' ), 0 );
 
-		add_filter( 'w3tc_admin_bar_menu',
-			array( $this, 'w3tc_admin_bar_menu' ) );
+		add_filter( 'w3tc_admin_bar_menu', array( $this, 'w3tc_admin_bar_menu' ) );
 
-		// usage statistics handling
-		add_action( 'w3tc_usage_statistics_of_request', array(
-				$this, 'w3tc_usage_statistics_of_request' ), 10, 1 );
-		add_filter( 'w3tc_usage_statistics_metrics', array(
-				$this, 'w3tc_usage_statistics_metrics' ) );
-		add_filter( 'w3tc_usage_statistics_sources', array(
-				$this, 'w3tc_usage_statistics_sources' ) );
-
+		// usage statistics handling.
+		add_action( 'w3tc_usage_statistics_of_request', array( $this, 'w3tc_usage_statistics_of_request' ), 10, 1 );
+		add_filter( 'w3tc_usage_statistics_metrics', array( $this, 'w3tc_usage_statistics_metrics' ) );
+		add_filter( 'w3tc_usage_statistics_sources', array( $this, 'w3tc_usage_statistics_sources' ) );
 
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'delete_blog', array(
-					$this,
-					'on_change'
-				), 0 );
-
-			add_action( 'switch_blog', array(
-					$this,
-					'switch_blog'
-				), 0, 2 );
+			add_action( 'delete_blog', array( $this, 'on_change' ), 0 );
+			add_action( 'switch_blog', array( $this, 'switch_blog' ), 0, 2 );
 		}
 	}
 
@@ -130,11 +81,13 @@ class ObjectCache_Plugin {
 	 *
 	 * @return void
 	 */
-	function cleanup() {
-		$w3_cache_file_cleaner = new Cache_File_Cleaner( array(
-				'cache_dir' => Util_Environment::cache_blog_dir( 'object' ),
-				'clean_timelimit' => $this->_config->get_integer( 'timelimit.cache_gc' )
-			) );
+	public function cleanup() {
+		$w3_cache_file_cleaner = new Cache_File_Cleaner(
+			array(
+				'cache_dir'       => Util_Environment::cache_blog_dir( 'object' ),
+				'clean_timelimit' => $this->_config->get_integer( 'timelimit.cache_gc' ),
+			)
+		);
 
 		$w3_cache_file_cleaner->clean();
 	}
@@ -142,27 +95,35 @@ class ObjectCache_Plugin {
 	/**
 	 * Cron schedules filter
 	 *
-	 * @param array   $schedules
+	 * @param array $schedules Schedules.
+	 *
 	 * @return array
 	 */
-	function cron_schedules( $schedules ) {
+	public function cron_schedules( $schedules ) {
 		$gc = $this->_config->get_integer( 'objectcache.file.gc' );
 
-		return array_merge( $schedules, array(
+		return array_merge(
+			$schedules,
+			array(
 				'w3_objectcache_cleanup' => array(
 					'interval' => $gc,
-					'display' => sprintf( '[W3TC] Object Cache file GC (every %d seconds)', $gc )
-				)
-			) );
+					'display'  => sprintf(
+						// translators: 1 interval in seconds.
+						__( '[W3TC] Object Cache file GC (every %d seconds)', 'w3-total-cache' ),
+						$gc
+					),
+				),
+			)
+		);
 	}
 
 	/**
 	 * Change action
 	 */
-	function on_change() {
+	public function on_change() {
 		static $flushed = false;
 
-		if ( !$flushed ) {
+		if ( ! $flushed ) {
 			$flush = Dispatcher::component( 'CacheFlush' );
 			$flush->objectcache_flush();
 			$flushed = true;
@@ -171,16 +132,19 @@ class ObjectCache_Plugin {
 
 	/**
 	 * Change post action
+	 *
+	 * @param integer $post_id Post ID.
+	 * @param mixed   $post Post.
 	 */
-	function on_post_change( $post_id = 0, $post = null ) {
+	public function on_post_change( $post_id = 0, $post = null ) {
 		static $flushed = false;
 
-		if ( !$flushed ) {
-			if ( is_null( $post ) )
+		if ( ! $flushed ) {
+			if ( is_null( $post ) ) {
 				$post = $post_id;
+			}
 
-			if ( $post_id> 0 && !Util_Environment::is_flushable_post(
-					$post, 'objectcache', $this->_config ) ) {
+			if ( $post_id > 0 && ! Util_Environment::is_flushable_post( $post, 'objectcache', $this->_config ) ) {
 				return;
 			}
 
@@ -192,28 +156,32 @@ class ObjectCache_Plugin {
 
 	/**
 	 * Change action
+	 *
+	 * @param string $option Option key.
 	 */
-	function on_change_option( $option ) {
+	public function on_change_option( $option ) {
 		static $flushed = false;
-/*
-		if ( !$flushed ) {
-			if ( $option != 'cron' ) {
+
+		/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		if ( ! $flushed ) {
+			if ( 'cron' !== $option ) {
 				$flush = Dispatcher::component( 'CacheFlush' );
 				$flush->objectcache_flush();
 				$flushed = true;
 			}
-		}*/
+		}
+		*/
 	}
 
 	/**
 	 * Flush cache when user profile is updated
 	 *
-	 * @param int     $user_id
+	 * @param integer $user_id User ID.
 	 */
-	function on_change_profile( $user_id ) {
+	public function on_change_profile( $user_id ) {
 		static $flushed = false;
 
-		if ( !$flushed ) {
+		if ( ! $flushed ) {
 			if ( Util_Environment::is_wpmu() ) {
 				$blogs = get_blogs_of_user( $user_id, true );
 				if ( $blogs ) {
@@ -231,8 +199,11 @@ class ObjectCache_Plugin {
 
 	/**
 	 * Switch blog action
+	 *
+	 * @param integer $blog_id Blog ID.
+	 * @param integer $previous_blog_id Previous Blog ID.
 	 */
-	function switch_blog( $blog_id, $previous_blog_id ) {
+	public function switch_blog( $blog_id, $previous_blog_id ) {
 		$o = Dispatcher::component( 'ObjectCache_WpObjectCache_Regular' );
 		$o->switch_blog( $blog_id );
 	}
@@ -241,15 +212,14 @@ class ObjectCache_Plugin {
 	/**
 	 * Comment change action
 	 *
-	 * @param integer $comment_id
+	 * @param integer $comment_id Comment ID.
 	 */
-	function on_comment_change( $comment_id ) {
+	public function on_comment_change( $comment_id ) {
 		$post_id = 0;
 
 		if ( $comment_id ) {
 			$comment = get_comment( $comment_id, ARRAY_A );
-			$post_id = ( !empty( $comment['comment_post_ID'] ) ?
-				(int) $comment['comment_post_ID'] : 0 );
+			$post_id = ( ! empty( $comment['comment_post_ID'] ) ? (int) $comment['comment_post_ID'] : 0 );
 		}
 
 		$this->on_post_change( $post_id );
@@ -258,47 +228,69 @@ class ObjectCache_Plugin {
 	/**
 	 * Comment status action
 	 *
-	 * @param integer $comment_id
-	 * @param string  $status
+	 * @param integer $comment_id Comment ID.
+	 * @param string  $status Status.
 	 */
-	function on_comment_status( $comment_id, $status ) {
-		if ( $status === 'approve' || $status === '1' ) {
+	public function on_comment_status( $comment_id, $status ) {
+		if ( 'approve' === $status || '1' === $status ) {
 			$this->on_comment_change( $comment_id );
 		}
 	}
 
+	/**
+	 * Setup admin menu elements
+	 *
+	 * @param array $menu_items Menu items.
+	 */
 	public function w3tc_admin_bar_menu( $menu_items ) {
 		$menu_items['20410.objectcache'] = array(
-			'id' => 'w3tc_flush_objectcache',
+			'id'     => 'w3tc_flush_objectcache',
 			'parent' => 'w3tc_flush',
-			'title' => __( 'Object Cache', 'w3-total-cache' ),
-			'href' => wp_nonce_url( admin_url(
-					'admin.php?page=w3tc_dashboard&amp;w3tc_flush_objectcache' ), 'w3tc' )
+			'title'  => __( 'Object Cache', 'w3-total-cache' ),
+			'href'   => wp_nonce_url( admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_objectcache' ), 'w3tc' ),
 		);
 
 		return $menu_items;
 	}
 
+	/**
+	 * Setup admin menu elements
+	 *
+	 * @param array $strings Strings.
+	 */
 	public function w3tc_footer_comment( $strings ) {
-		$o = Dispatcher::component( 'ObjectCache_WpObjectCache_Regular' );
+		$o       = Dispatcher::component( 'ObjectCache_WpObjectCache_Regular' );
 		$strings = $o->w3tc_footer_comment( $strings );
 
 		return $strings;
 	}
 
+	/**
+	 * Usage statistics of request filter
+	 *
+	 * @param object $storage Storage object.
+	 */
 	public function w3tc_usage_statistics_of_request( $storage ) {
 		$o = Dispatcher::component( 'ObjectCache_WpObjectCache_Regular' );
 		$o->w3tc_usage_statistics_of_request( $storage );
 	}
 
+	/**
+	 * Retrive usage statistics metrics
+	 *
+	 * @param array $metrics Metrics.
+	 */
 	public function w3tc_usage_statistics_metrics( $metrics ) {
-		$metrics = array_merge( $metrics, array(
-			'objectcache_get_total',
-			'objectcache_get_hits',
-			'objectcache_sets',
-			'objectcache_flushes',
-			'objectcache_time_ms'
-		) );
+		$metrics = array_merge(
+			$metrics,
+			array(
+				'objectcache_get_total',
+				'objectcache_get_hits',
+				'objectcache_sets',
+				'objectcache_flushes',
+				'objectcache_time_ms',
+			)
+		);
 
 		return $metrics;
 	}
@@ -339,12 +331,12 @@ class ObjectCache_Plugin {
 	}
 
 	/**
-	 *
+	 * Returns flag for flushable.
 	 *
 	 * @return bool
 	 */
-	private function _do_flush() {
-		//TODO: Requires admin flush until OC can make changes in Admin backend
+	private function _do_flush() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+		// TODO: Requires admin flush until OC can make changes in Admin backend.
 		return $this->_config->get_boolean( 'cluster.messagebus.enabled' )
 			|| $this->_config->get_boolean( 'objectcache.purge.all' )
 			|| defined( 'WP_ADMIN' );

--- a/ObjectCache_Plugin.php
+++ b/ObjectCache_Plugin.php
@@ -320,6 +320,7 @@ class ObjectCache_Plugin {
 		} elseif ( $c->get_string( 'objectcache.engine' ) == 'redis' ) {
 			$sources['redis_servers']['objectcache'] = array(
 				'servers' => $c->get_array( 'objectcache.redis.servers' ),
+				'verify_tls_certificates' => $c->get_boolean( 'objectcache.redis.verify_tls_certificates' ),
 				'username' => $c->get_boolean( 'objectcache.redis.username' ),
 				'dbid' => $c->get_integer( 'objectcache.redis.dbid' ),
 				'password' => $c->get_string( 'objectcache.redis.password' ),

--- a/ObjectCache_Plugin.php
+++ b/ObjectCache_Plugin.php
@@ -303,28 +303,35 @@ class ObjectCache_Plugin {
 		return $metrics;
 	}
 
-	public function w3tc_usage_statistics_sources($sources) {
+	/**
+	 * Usage Statisitcs sources filter.
+	 *
+	 * @param array $sources Sources.
+	 *
+	 * @return array
+	 */
+	public function w3tc_usage_statistics_sources( $sources ) {
 		$c = Dispatcher::config();
-		if ( $c->get_string( 'objectcache.engine' ) == 'apc' ) {
+		if ( 'apc' === $c->get_string( 'objectcache.engine' ) ) {
 			$sources['apc_servers']['objectcache'] = array(
-				'name' => __( 'Object Cache', 'w3-total-cache' )
+				'name' => __( 'Object Cache', 'w3-total-cache' ),
 			);
-		} elseif ( $c->get_string( 'objectcache.engine' ) == 'memcached' ) {
+		} elseif ( 'memcached' === $c->get_string( 'objectcache.engine' ) ) {
 			$sources['memcached_servers']['objectcache'] = array(
-				'servers' => $c->get_array( 'objectcache.memcached.servers' ),
-				'username' => $c->get_string( 'objectcache.memcached.username' ),
-				'password' => $c->get_string( 'objectcache.memcached.password' ),
+				'servers'         => $c->get_array( 'objectcache.memcached.servers' ),
+				'username'        => $c->get_string( 'objectcache.memcached.username' ),
+				'password'        => $c->get_string( 'objectcache.memcached.password' ),
 				'binary_protocol' => $c->get_boolean( 'objectcache.memcached.binary_protocol' ),
-				'name' => __( 'Object Cache', 'w3-total-cache' )
+				'name'            => __( 'Object Cache', 'w3-total-cache' ),
 			);
-		} elseif ( $c->get_string( 'objectcache.engine' ) == 'redis' ) {
+		} elseif ( 'redis' === $c->get_string( 'objectcache.engine' ) ) {
 			$sources['redis_servers']['objectcache'] = array(
-				'servers' => $c->get_array( 'objectcache.redis.servers' ),
+				'servers'                 => $c->get_array( 'objectcache.redis.servers' ),
 				'verify_tls_certificates' => $c->get_boolean( 'objectcache.redis.verify_tls_certificates' ),
-				'username' => $c->get_boolean( 'objectcache.redis.username' ),
-				'dbid' => $c->get_integer( 'objectcache.redis.dbid' ),
-				'password' => $c->get_string( 'objectcache.redis.password' ),
-				'name' => __( 'Object Cache', 'w3-total-cache' )
+				'username'                => $c->get_boolean( 'objectcache.redis.username' ),
+				'dbid'                    => $c->get_integer( 'objectcache.redis.dbid' ),
+				'password'                => $c->get_string( 'objectcache.redis.password' ),
+				'name'                    => __( 'Object Cache', 'w3-total-cache' ),
 			);
 		}
 

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -286,6 +286,7 @@ class PgCache_Plugin {
 		} elseif ( $c->get_string( 'pgcache.engine' ) == 'redis' ) {
 			$sources['redis_servers']['pgcache'] = array(
 				'servers' => $c->get_array( 'pgcache.redis.servers' ),
+				'verify_tls_certificates' => $c->get_boolean( 'pgcache.redis.verify_tls_certificates' ),
 				'dbid' => $c->get_integer( 'pgcache.redis.dbid' ),
 				'password' => $c->get_string( 'pgcache.redis.password' ),
 				'name' => __( 'Page Cache', 'w3-total-cache' )

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -269,27 +269,34 @@ class PgCache_Plugin {
 				'pagecache_requests_time_10ms' ) );
 	}
 
+	/**
+	 * Usage Statisitcs sources filter.
+	 *
+	 * @param array $sources Sources.
+	 *
+	 * @return array
+	 */
 	public function w3tc_usage_statistics_sources( $sources ) {
 		$c = Dispatcher::config();
-		if ( $c->get_string( 'pgcache.engine' ) == 'apc' ) {
+		if ( 'apc' === $c->get_string( 'pgcache.engine' ) ) {
 			$sources['apc_servers']['pgcache'] = array(
 				'name' => __( 'Page Cache', 'w3-total-cache' )
 			);
-		} elseif ( $c->get_string( 'pgcache.engine' ) == 'memcached' ) {
+		} elseif ( 'memcached' === $c->get_string( 'pgcache.engine' ) ) {
 			$sources['memcached_servers']['pgcache'] = array(
-				'servers' => $c->get_array( 'pgcache.memcached.servers' ),
-				'username' => $c->get_string( 'pgcache.memcached.username' ),
-				'password' => $c->get_string( 'pgcache.memcached.password' ),
+				'servers'         => $c->get_array( 'pgcache.memcached.servers' ),
+				'username'        => $c->get_string( 'pgcache.memcached.username' ),
+				'password'        => $c->get_string( 'pgcache.memcached.password' ),
 				'binary_protocol' => $c->get_boolean( 'pgcache.memcached.binary_protocol' ),
-				'name' => __( 'Page Cache', 'w3-total-cache' )
+				'name'            => __( 'Page Cache', 'w3-total-cache' ),
 			);
-		} elseif ( $c->get_string( 'pgcache.engine' ) == 'redis' ) {
+		} elseif ( 'redis' === $c->get_string( 'pgcache.engine' ) ) {
 			$sources['redis_servers']['pgcache'] = array(
-				'servers' => $c->get_array( 'pgcache.redis.servers' ),
+				'servers'                 => $c->get_array( 'pgcache.redis.servers' ),
 				'verify_tls_certificates' => $c->get_boolean( 'pgcache.redis.verify_tls_certificates' ),
-				'dbid' => $c->get_integer( 'pgcache.redis.dbid' ),
-				'password' => $c->get_string( 'pgcache.redis.password' ),
-				'name' => __( 'Page Cache', 'w3-total-cache' )
+				'dbid'                    => $c->get_integer( 'pgcache.redis.dbid' ),
+				'password'                => $c->get_string( 'pgcache.redis.password' ),
+				'name'                    => __( 'Page Cache', 'w3-total-cache' ),
 			);
 		}
 

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * File: PgCache_Plugin.php
+ *
+ * @package W3TC
+ *
+ * phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+ */
+
 namespace W3TC;
 
 /**
@@ -6,137 +14,110 @@ namespace W3TC;
  */
 class PgCache_Plugin {
 	/**
-	 * Config
+	 * Config.
+	 *
+	 * @var array
 	 */
 	private $_config = null;
 
-	function __construct() {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
 		$this->_config = Dispatcher::config();
 	}
 
 	/**
 	 * Runs plugin
 	 */
-	function run() {
-		add_action( 'w3tc_flush_all',
-			array( $this, 'w3tc_flush_posts' ),
-			1100, 1 );
-		add_action( 'w3tc_flush_group',
-			array( $this, 'w3tc_flush_group' ),
-			1100, 2 );
-		add_action( 'w3tc_flush_post',
-			array( $this, 'w3tc_flush_post' ),
-			1100, 1 );
-		add_action( 'w3tc_flushable_posts',
-			'__return_true',
-			1100 );
-		add_action( 'w3tc_flush_posts',
-			array( $this, 'w3tc_flush_posts' ),
-			1100 );
-		add_action( 'w3tc_flush_url',
-			array( $this, 'w3tc_flush_url' ),
-			1100, 1 );
+	public function run() {
+		add_action( 'w3tc_flush_all', array( $this, 'w3tc_flush_posts' ), 1100, 1 );
+		add_action( 'w3tc_flush_group', array( $this, 'w3tc_flush_group' ), 1100, 2 );
+		add_action( 'w3tc_flush_post', array( $this, 'w3tc_flush_post' ), 1100, 1 );
+		add_action( 'w3tc_flushable_posts', '__return_true', 1100 );
+		add_action( 'w3tc_flush_posts', array( $this, 'w3tc_flush_posts' ), 1100 );
+		add_action( 'w3tc_flush_url', array( $this, 'w3tc_flush_url' ), 1100, 1 );
 
-		add_filter( 'w3tc_pagecache_set_header',
-			array( $this, 'w3tc_pagecache_set_header' ), 10, 3 );
-		add_filter( 'w3tc_admin_bar_menu',
-			array( $this, 'w3tc_admin_bar_menu' ) );
+		add_filter( 'w3tc_pagecache_set_header', array( $this, 'w3tc_pagecache_set_header' ), 10, 3 );
+		add_filter( 'w3tc_admin_bar_menu', array( $this, 'w3tc_admin_bar_menu' ) );
 
-		add_filter( 'cron_schedules',
-			array( $this, 'cron_schedules' ) );
+		// phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
+		add_filter( 'cron_schedules', array( $this, 'cron_schedules' ) );
 
-		add_action( 'w3tc_config_save',
-			array( $this, 'w3tc_config_save' ),
-			10, 1 );
+		add_action( 'w3tc_config_save', array( $this, 'w3tc_config_save' ), 10, 1 );
 
 		$o = Dispatcher::component( 'PgCache_ContentGrabber' );
 
-		add_filter( 'w3tc_footer_comment',
-			array( $o, 'w3tc_footer_comment' ) );
+		add_filter( 'w3tc_footer_comment', array( $o, 'w3tc_footer_comment' ) );
 
-		add_action( 'w3tc_usage_statistics_of_request',
-			array( $o, 'w3tc_usage_statistics_of_request' ),
-			10, 1 );
-		add_filter( 'w3tc_usage_statistics_metrics',
-			array( $this, 'w3tc_usage_statistics_metrics' ) );
-		add_filter( 'w3tc_usage_statistics_sources', array(
-				$this, 'w3tc_usage_statistics_sources' ) );
+		// usage statistics handling.
+		add_action( 'w3tc_usage_statistics_of_request', array( $o, 'w3tc_usage_statistics_of_request' ), 10, 1 );
+		add_filter( 'w3tc_usage_statistics_metrics', array( $this, 'w3tc_usage_statistics_metrics' ) );
+		add_filter( 'w3tc_usage_statistics_sources', array( $this, 'w3tc_usage_statistics_sources' ) );
 
-
-		if ( $this->_config->get_string( 'pgcache.engine' ) == 'file' ||
-			$this->_config->get_string( 'pgcache.engine' ) == 'file_generic' ) {
-			add_action( 'w3_pgcache_cleanup',
-				array( $this, 'cleanup' ) );
+		if ( 'file' === $this->_config->get_string( 'pgcache.engine' ) ||
+			'file_generic' === $this->_config->get_string( 'pgcache.engine' ) ) {
+			add_action( 'w3_pgcache_cleanup', array( $this, 'cleanup' ) );
 		}
 
 		add_action( 'w3_pgcache_prime', array( $this, 'prime' ) );
 
 		Util_AttachToActions::flush_posts_on_actions();
 
-		add_filter( 'comment_cookie_lifetime',
-			array( $this, 'comment_cookie_lifetime' ) );
+		add_filter( 'comment_cookie_lifetime', array( $this, 'comment_cookie_lifetime' ) );
 
-		if ( $this->_config->get_string( 'pgcache.engine' ) == 'file_generic' ) {
-			add_action( 'wp_logout',
-				array( $this, 'on_logout' ),
-				0 );
-
-			add_action( 'wp_login',
-				array( $this, 'on_login' ),
-				0 );
+		if ( 'file_generic' === $this->_config->get_string( 'pgcache.engine' ) ) {
+			add_action( 'wp_logout', array( $this, 'on_logout' ), 0 );
+			add_action( 'wp_login', array( $this, 'on_login' ), 0 );
 		}
 
 		if ( $this->_config->get_boolean( 'pgcache.prime.post.enabled', false ) ) {
-			add_action( 'publish_post',
-				array( $this, 'prime_post' ),
-				30 );
+			add_action( 'publish_post', array( $this, 'prime_post' ), 30 );
 		}
 
 		if ( ( $this->_config->get_boolean( 'pgcache.late_init' ) ||
-				$this->_config->get_boolean( 'pgcache.late_caching' ) ) &&
-			!is_admin() ) {
+			$this->_config->get_boolean( 'pgcache.late_caching' ) ) &&
+			! is_admin() ) {
 			$o = Dispatcher::component( 'PgCache_ContentGrabber' );
-			add_action( 'init',
-				array( $o, 'delayed_cache_print' ),
-				99999 );
+			add_action( 'init', array( $o, 'delayed_cache_print' ), 99999 );
 		}
 
-		if ( !$this->_config->get_boolean( 'pgcache.mirrors.enabled' ) &&
-			!Util_Environment::is_wpmu_subdomain() ) {
-			add_action( 'init',
-				array( $this, 'redirect_on_foreign_domain' ) );
+		if ( ! $this->_config->get_boolean( 'pgcache.mirrors.enabled' ) &&
+			! Util_Environment::is_wpmu_subdomain() ) {
+			add_action( 'init', array( $this, 'redirect_on_foreign_domain' ) );
 		}
-		if ( $this->_config->get_string( 'pgcache.rest' ) == 'disable' ) {
-			// remove XMLRPC edit link
+		if ( 'disable' === $this->_config->get_string( 'pgcache.rest' ) ) {
+			// remove XMLRPC edit link.
 			remove_action( 'xmlrpc_rsd_apis', 'rest_output_rsd' );
-			// remove wp-json in <head>
+			// remove wp-json in <head>.
 			remove_action( 'wp_head', 'rest_output_link_wp_head', 10 );
-			// remove HTTP Header
+			// remove HTTP Header.
 			remove_action( 'template_redirect', 'rest_output_link_header', 11 );
 
-			add_filter( 'rest_authentication_errors',
-				array( $this, 'rest_authentication_errors' ),
-				100 );
+			add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ), 100 );
 		}
 	}
 
-
-
+	/**
+	 * Get authentication WP Error.
+	 *
+	 * @param mixed $result Result.
+	 *
+	 * @return WP_Error
+	 */
 	public function rest_authentication_errors( $result ) {
 		$error_message = __( 'REST API disabled.', 'w3-total-cache' );
 
 		return new \WP_Error( 'rest_disabled', $error_message, array( 'status' => rest_authorization_required_code() ) );
 	}
 
-
-
 	/**
 	 * Does disk cache cleanup
 	 *
 	 * @return void
 	 */
-	function cleanup() {
-		$this->_get_admin()->cleanup();
+	public function cleanup() {
+		$this->get_admin()->cleanup();
 	}
 
 	/**
@@ -144,117 +125,149 @@ class PgCache_Plugin {
 	 *
 	 * @return void
 	 */
-	function prime() {
-		$this->_get_admin()->prime();
+	public function prime() {
+		$this->get_admin()->prime();
 	}
 
 	/**
 	 * Instantiates worker on demand
 	 */
-	private function _get_admin() {
+	private function get_admin() {
 		return Dispatcher::component( 'PgCache_Plugin_Admin' );
 	}
 
 	/**
 	 * Cron schedules filter
 	 *
-	 * @param array   $schedules
+	 * @param array $schedules Schedules.
+	 *
 	 * @return array
 	 */
-	function cron_schedules( $schedules ) {
+	public function cron_schedules( $schedules ) {
 		$c = $this->_config;
 
 		if ( $c->get_boolean( 'pgcache.enabled' ) &&
-			( $c->get_string( 'pgcache.engine' ) == 'file' ||
-				$c->get_string( 'pgcache.engine' ) == 'file_generic' ) ) {
-			$v = $c->get_integer( 'pgcache.file.gc' );
+			( 'file' === $c->get_string( 'pgcache.engine' ) ||
+			'file_generic' === $c->get_string( 'pgcache.engine' ) ) ) {
+			$v                               = $c->get_integer( 'pgcache.file.gc' );
 			$schedules['w3_pgcache_cleanup'] = array(
 				'interval' => $v,
-				'display' => sprintf( '[W3TC] Page Cache file GC (every %d seconds)',
-					$v )
+				'display'  => sprintf(
+					// translators: 1 interval in seconds.
+					__( '[W3TC] Page Cache file GC (every %d seconds)', 'w3-total-cache' ),
+					$v
+				),
 			);
 		}
 
 		if ( $c->get_boolean( 'pgcache.enabled' ) &&
 			$c->get_boolean( 'pgcache.prime.enabled' ) ) {
-			$v = $c->get_integer( 'pgcache.prime.interval' );
+			$v                             = $c->get_integer( 'pgcache.prime.interval' );
 			$schedules['w3_pgcache_prime'] = array(
 				'interval' => $v,
-				'display' => sprintf( '[W3TC] Page Cache prime (every %d seconds)',
-					$v )
+				'display'  => sprintf(
+					// translators: 1 interval in seconds.
+					__( '[W3TC] Page Cache prime (every %d seconds)', 'w3-total-cache' ),
+					$v
+				),
 			);
 		}
 
 		return $schedules;
 	}
 
+	/**
+	 * Redirect if foreign domain or WP_CLI.
+	 */
 	public function redirect_on_foreign_domain() {
 		$request_host = Util_Environment::host();
-		// host not known, potentially we are in console mode not http request
-		if ( empty( $request_host ) || defined( 'WP_CLI' ) && WP_CLI )
-			return;
 
-		$home_url = get_home_url();
-		$parsed_url = @parse_url( $home_url );
+		// host not known, potentially we are in console mode not http request.
+		if ( empty( $request_host ) || defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+
+		$home_url   = get_home_url();
+		$parsed_url = @wp_parse_url( $home_url ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
 		if ( isset( $parsed_url['host'] ) &&
-			strtolower( $parsed_url['host'] ) != strtolower( $request_host ) ) {
+			strtolower( $parsed_url['host'] ) !== strtolower( $request_host ) ) {
 			$redirect_url = $parsed_url['scheme'] . '://';
-			if ( !empty( $parsed_url['user'] ) ) {
-				$redirect_url .= $parsed_url['user'];
-				if ( !empty( $parsed_url['pass'] ) )
-					$redirect_url .= ':' . $parsed_url['pass'];
-			}
-			if ( !empty( $parsed_url['host'] ) )
-				$redirect_url .= $parsed_url['host'];
 
-			if ( !empty( $parsed_url['port'] ) && $parsed_url['port'] != 80 ) {
-				$redirect_url .= ':' . (int)$parsed_url['port'];
+			if ( ! empty( $parsed_url['user'] ) ) {
+				$redirect_url .= $parsed_url['user'];
+				if ( ! empty( $parsed_url['pass'] ) ) {
+					$redirect_url .= ':' . $parsed_url['pass'];
+				}
+			}
+
+			if ( ! empty( $parsed_url['host'] ) ) {
+				$redirect_url .= $parsed_url['host'];
+			}
+
+			if ( ! empty( $parsed_url['port'] ) && 80 !== (int) $parsed_url['port'] ) {
+				$redirect_url .= ':' . (int) $parsed_url['port'];
 			}
 
 			$redirect_url .= isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-			wp_redirect( $redirect_url, 301 );
+			wp_safe_redirect( $redirect_url, 301 );
+
 			exit();
 		}
 	}
 
-	function comment_cookie_lifetime( $lifetime ) {
+	/**
+	 * Get comment cookie lifetime
+	 *
+	 * @param integer $lifetime Comment cookie lifetime.
+	 */
+	public function comment_cookie_lifetime( $lifetime ) {
 		$l = $this->_config->get_integer( 'pgcache.comment_cookie_ttl' );
-		if ( $l != -1 )
+		if ( -1 !== $l ) {
 			return $l;
-		else
+		} else {
 			return $lifetime;
+		}
 	}
 
 	/**
 	 * Add cookie on logout to circumvent pagecache due to browser cache resulting in 304s
 	 */
-	function on_logout() {
+	public function on_logout() {
 		setcookie( 'w3tc_logged_out' );
 	}
 
 	/**
 	 * Remove logout cookie on logins
 	 */
-	function on_login() {
-		if ( isset( $_COOKIE['w3tc_logged_out'] ) )
+	public function on_login() {
+		if ( isset( $_COOKIE['w3tc_logged_out'] ) ) {
 			setcookie( 'w3tc_logged_out', '', 1 );
+		}
 	}
 
 	/**
+	 * Primes post.
 	 *
+	 * @param integer $post_id Post ID.
 	 *
-	 * @param unknown $post_id
 	 * @return boolean
 	 */
-	function prime_post( $post_id ) {
+	public function prime_post( $post_id ) {
 		$w3_pgcache = Dispatcher::component( 'CacheFlush' );
 		return $w3_pgcache->prime_post( $post_id );
 	}
 
+	/**
+	 * Retrive usage statistics metrics
+	 *
+	 * @param array $metrics Metrics.
+	 */
 	public function w3tc_usage_statistics_metrics( $metrics ) {
-		return array_merge( $metrics, array(
+		return array_merge(
+			$metrics,
+			array(
 				'php_requests_pagecache_hit',
 				'php_requests_pagecache_miss_404',
 				'php_requests_pagecache_miss_ajax',
@@ -266,7 +279,9 @@ class PgCache_Plugin {
 				'php_requests_pagecache_miss_query_string',
 				'php_requests_pagecache_miss_third_party',
 				'php_requests_pagecache_miss_wp_admin',
-				'pagecache_requests_time_10ms' ) );
+				'pagecache_requests_time_10ms',
+			)
+		);
 	}
 
 	/**
@@ -280,7 +295,7 @@ class PgCache_Plugin {
 		$c = Dispatcher::config();
 		if ( 'apc' === $c->get_string( 'pgcache.engine' ) ) {
 			$sources['apc_servers']['pgcache'] = array(
-				'name' => __( 'Page Cache', 'w3-total-cache' )
+				'name' => __( 'Page Cache', 'w3-total-cache' ),
 			);
 		} elseif ( 'memcached' === $c->get_string( 'pgcache.engine' ) ) {
 			$sources['memcached_servers']['pgcache'] = array(
@@ -303,36 +318,50 @@ class PgCache_Plugin {
 		return $sources;
 	}
 
+	/**
+	 * Setup admin menu elements
+	 *
+	 * @param array $menu_items Menu items.
+	 */
 	public function w3tc_admin_bar_menu( $menu_items ) {
 		$menu_items['20110.pagecache'] = array(
-			'id' => 'w3tc_flush_pgcache',
+			'id'     => 'w3tc_flush_pgcache',
 			'parent' => 'w3tc_flush',
-			'title' => __( 'Page Cache: All', 'w3-total-cache' ),
-			'href' => wp_nonce_url( admin_url(
-					'admin.php?page=w3tc_dashboard&amp;w3tc_flush_pgcache' ),
-				'w3tc' )
+			'title'  => __( 'Page Cache: All', 'w3-total-cache' ),
+			'href'   => wp_nonce_url( admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_pgcache' ), 'w3tc' ),
 		);
 
-		if ( Util_Environment::detect_post_id() && ( !defined( 'DOING_AJAX' ) || !DOING_AJAX ) ) {
+		if ( Util_Environment::detect_post_id() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
 			$menu_items['20120.pagecache'] = array(
-				'id' => 'w3tc_pgcache_flush_post',
+				'id'     => 'w3tc_pgcache_flush_post',
 				'parent' => 'w3tc_flush',
-				'title' => __( 'Page Cache: Current Page', 'w3-total-cache' ),
-				'href' => wp_nonce_url( admin_url(
+				'title'  => __( 'Page Cache: Current Page', 'w3-total-cache' ),
+				'href'   => wp_nonce_url(
+					admin_url(
 						'admin.php?page=w3tc_dashboard&amp;w3tc_flush_post&amp;post_id=' .
-						Util_Environment::detect_post_id() ), 'w3tc' )
+							Util_Environment::detect_post_id()
+					),
+					'w3tc'
+				),
 			);
 		}
 
 		return $menu_items;
 	}
 
-	function w3tc_flush_group( $group, $extras = array() ) {
-		if ( isset( $extras['only'] ) && $extras['only'] != 'pagecache' )
+	/**
+	 * Flush cache group.
+	 *
+	 * @param string $group Group name.
+	 * @param array  $extras Additionals to flush.
+	 */
+	public function w3tc_flush_group( $group, $extras = array() ) {
+		if ( isset( $extras['only'] ) && 'pagecache' !== (string) $extras['only'] ) {
 			return;
+		}
 
 		$pgcacheflush = Dispatcher::component( 'PgCache_Flush' );
-		$v = $pgcacheflush->flush_group( $group );
+		$v            = $pgcacheflush->flush_group( $group );
 
 		return $v;
 	}
@@ -340,14 +369,17 @@ class PgCache_Plugin {
 	/**
 	 * Flushes all caches
 	 *
+	 * @param array $extras Additionals to flush.
+	 *
 	 * @return boolean
 	 */
-	function w3tc_flush_posts( $extras = array() ) {
-		if ( isset( $extras['only'] ) && $extras['only'] != 'pagecache' )
+	public function w3tc_flush_posts( $extras = array() ) {
+		if ( isset( $extras['only'] ) && 'pagecache' !== (string) $extras['only'] ) {
 			return;
+		}
 
 		$pgcacheflush = Dispatcher::component( 'PgCache_Flush' );
-		$v = $pgcacheflush->flush();
+		$v            = $pgcacheflush->flush();
 
 		return $v;
 	}
@@ -355,12 +387,13 @@ class PgCache_Plugin {
 	/**
 	 * Flushes post cache
 	 *
-	 * @param integer $post_id
+	 * @param integer $post_id Post ID.
+	 *
 	 * @return boolean
 	 */
-	function w3tc_flush_post( $post_id ) {
+	public function w3tc_flush_post( $post_id ) {
 		$pgcacheflush = Dispatcher::component( 'PgCache_Flush' );
-		$v = $pgcacheflush->flush_post( $post_id );
+		$v            = $pgcacheflush->flush_post( $post_id );
 
 		return $v;
 	}
@@ -368,12 +401,13 @@ class PgCache_Plugin {
 	/**
 	 * Flushes post cache
 	 *
-	 * @param string  $url
+	 * @param string $url URL.
+	 *
 	 * @return boolean
 	 */
-	function w3tc_flush_url( $url ) {
+	public function w3tc_flush_url( $url ) {
 		$pgcacheflush = Dispatcher::component( 'PgCache_Flush' );
-		$v = $pgcacheflush->flush_url( $url );
+		$v            = $pgcacheflush->flush_url( $url );
 
 		return $v;
 	}
@@ -382,23 +416,30 @@ class PgCache_Plugin {
 
 	/**
 	 * By default headers are not cached by file_generic
+	 *
+	 * @param mixed  $header New header.
+	 * @param mixed  $header_original Original header.
+	 * @param string $pagecache_engine Engine name.
+	 *
+	 * @return mixed|null
 	 */
-	public function w3tc_pagecache_set_header( $header, $header_original,
-			$pagecache_engine ) {
-		if ( $pagecache_engine == 'file_generic' ) {
+	public function w3tc_pagecache_set_header( $header, $header_original, $pagecache_engine ) {
+		if ( 'file_generic' === (string) $pagecache_engine ) {
 			return null;
 		}
 
 		return $header;
 	}
 
-
-
+	/**
+	 * Save config item
+	 *
+	 * @param array $config Config.
+	 */
 	public function w3tc_config_save( $config ) {
-		// frontend activity
+		// frontend activity.
 		if ( $config->get_boolean( 'pgcache.cache.feed' ) ) {
 			$config->set( 'pgcache.cache.nginx_handle_xml', true );
 		}
 	}
-
 }

--- a/UsageStatistics_Sources_Redis.php
+++ b/UsageStatistics_Sources_Redis.php
@@ -1,47 +1,66 @@
 <?php
+/**
+ * File: UsageStatistics_Sources_Redis.php
+ *
+ * @package W3TC
+ */
+
 namespace W3TC;
 
-
-
+/**
+ * Usage Statistics Sources for Redis
+ */
 class UsageStatistics_Sources_Redis {
+	/**
+	 * Servers.
+	 *
+	 * @var array
+	 */
 	private $servers;
 
-
-
+	/**
+	 * Constructor.
+	 *
+	 * @param array $server_descriptors Server desriptors.
+	 */
 	public function __construct( $server_descriptors ) {
 		$this->servers = array();
 
 		foreach ( $server_descriptors as $i ) {
 			foreach ( $i['servers'] as $host_port ) {
-				if ( !isset( $this->servers[$host_port] ) )
-					$this->servers[$host_port] = array(
-						'password' => $i['password'],
-						'dbid' => $i['dbid'],
-						'module_names' => array( $i['name'] )
+				if ( ! isset( $this->servers[ $host_port ] ) ) {
+					$this->servers[ $host_port ] = array(
+						'password'     => $i['password'],
+						'dbid'         => $i['dbid'],
+						'module_names' => array( $i['name'] ),
 					);
-				else
-					$this->servers[$host_port]['module_names'][] = $i['name'];
+				} else {
+					$this->servers[ $host_port ]['module_names'][] = $i['name'];
+				}
 			}
 		}
 	}
 
-
-
+	/**
+	 * Get snapshot stats.
+	 */
 	public function get_snapshot() {
 		$size_used = 0;
 		$get_calls = 0;
-		$get_hits = 0;
+		$get_hits  = 0;
 
 		foreach ( $this->servers as $host_port => $i ) {
-			$cache = Cache::instance( 'redis',
+			$cache = Cache::instance(
+				'redis',
 				array(
-					'servers' => array( $host_port ),
-					'password' => $i['password'],
-					'dbid' => $i['dbid'],
-					'timeout' => 0,
+					'servers'        => array( $host_port ),
+					'password'       => $i['password'],
+					'dbid'           => $i['dbid'],
+					'timeout'        => 0,
 					'retry_interval' => 0,
-					'read_timeout' => 0,
-				) );
+					'read_timeout'   => 0,
+				)
+			);
 
 			$stats = $cache->get_statistics();
 
@@ -49,99 +68,61 @@ class UsageStatistics_Sources_Redis {
 			$get_calls +=
 				Util_UsageStatistics::v3( $stats, 'keyspace_hits' ) +
 				Util_UsageStatistics::v3( $stats, 'keyspace_misses' );
-			$get_hits += Util_UsageStatistics::v( $stats, 'keyspace_hits' );
+			$get_hits  += Util_UsageStatistics::v( $stats, 'keyspace_hits' );
 		}
 
 		return array(
 			'size_used' => $size_used,
 			'get_calls' => $get_calls,
-			'get_hits' => $get_hits
+			'get_hits'  => $get_hits,
 		);
 	}
 
-
-
+	/**
+	 * Get stats summary.
+	 */
 	public function get_summary() {
 		$sum = array(
-			'module_names' => array(),
-			'size_used' => 0,
+			'module_names'  => array(),
+			'size_used'     => 0,
 			'size_maxbytes' => 0,
-			'get_total' => 0,
-			'get_hits' => 0,
-			'evictions' => 0,
-			'uptime' => 0
+			'get_total'     => 0,
+			'get_hits'      => 0,
+			'evictions'     => 0,
+			'uptime'        => 0,
 		);
 
 		foreach ( $this->servers as $host_port => $i ) {
-			$cache = Cache::instance( 'redis',
+			$cache = Cache::instance(
+				'redis',
 				array(
-					'servers' => array( $host_port ),
-					'password' => $i['password'],
-					'dbid' => $i['dbid'],
-					'timeout' => 0,
+					'servers'        => array( $host_port ),
+					'password'       => $i['password'],
+					'dbid'           => $i['dbid'],
+					'timeout'        => 0,
 					'retry_interval' => 0,
-					'read_timeout' => 0,
-				) );
+					'read_timeout'   => 0,
+				)
+			);
 
 			$stats = $cache->get_statistics();
 
-			$sum['module_names'] =
-				array_merge( $sum['module_names'], $i['module_names'] );
-			$sum['size_used'] += Util_UsageStatistics::v3( $stats, 'used_memory');
-			$sum['get_total'] +=
+			$sum['module_names'] = array_merge( $sum['module_names'], $i['module_names'] );
+			$sum['size_used']   += Util_UsageStatistics::v3( $stats, 'used_memory' );
+			$sum['get_total']   +=
 				Util_UsageStatistics::v3( $stats, 'keyspace_hits' ) +
 				Util_UsageStatistics::v3( $stats, 'keyspace_misses' );
-			$sum['get_hits'] += Util_UsageStatistics::v3( $stats, 'keyspace_hits' );
-			$sum['evictions'] += Util_UsageStatistics::v3( $stats, 'evicted_keys' );
-			$sum['uptime'] += Util_UsageStatistics::v3( $stats, 'uptime_in_seconds' );
+			$sum['get_hits']    += Util_UsageStatistics::v3( $stats, 'keyspace_hits' );
+			$sum['evictions']   += Util_UsageStatistics::v3( $stats, 'evicted_keys' );
+			$sum['uptime']      += Util_UsageStatistics::v3( $stats, 'uptime_in_seconds' );
 		}
 
 		$summary = array(
-			'module_names' => implode( ',', $sum['module_names'] ),
-			'size_used' => Util_UsageStatistics::bytes_to_size2(
-				$sum, 'size_used' ),
-			'get_hit_rate' => Util_UsageStatistics::percent2(
-				$sum, 'get_hits', 'get_total' ),
-			'evictions_per_second' => Util_UsageStatistics::value_per_second(
-				$sum, 'evictions', 'uptime' )
+			'module_names'         => implode( ',', $sum['module_names'] ),
+			'size_used'            => Util_UsageStatistics::bytes_to_size2( $sum, 'size_used' ),
+			'get_hit_rate'         => Util_UsageStatistics::percent2( $sum, 'get_hits', 'get_total' ),
+			'evictions_per_second' => Util_UsageStatistics::value_per_second( $sum, 'evictions', 'uptime' ),
 		);
-
-		return $summary;
-
-
-		$summary = array();
-
-		foreach ( $servers as $host_port => $i ) {
-			$cache = Cache::instance( 'redis',
-				array(
-					'servers' => array( $host_port ),
-					'password' => $i['password'],
-					'dbid' => $i['dbid'],
-					'timeout' => 0,
-					'retry_interval' => 0,
-					'read_timeout' => 0,
-				) );
-
-			$stats = $cache->get_statistics();
-
-			if ( isset( $stats['keyspace_hits'] ) && $stats['keyspace_misses'] )
-				$stats['_keyspace_total'] =
-					(int)$stats['keyspace_hits'] + (int)$stats['keyspace_misses'];
-
-			$id = md5( $host_port );
-			$summary[$id] = array(
-				'name' => $host_port,
-				'module_names' => $i['module_names'],
-				'size_used' =>
-				Util_UsageStatistics::bytes_to_size2( $stats, 'used_memory' ),
-				'hit_rate' =>
-				Util_UsageStatistics::percent2( $stats, 'keyspace_hits', '_keyspace_total' ),
-				'expirations_per_second' => Util_UsageStatistics::value_per_second(
-					$stats, 'expired_keys', 'uptime_in_seconds' ),
-				'evictions_per_second' => Util_UsageStatistics::value_per_second(
-					$stats, 'evicted_keys', 'uptime_in_seconds' )
-			);
-		}
 
 		return $summary;
 	}

--- a/UsageStatistics_Sources_Redis.php
+++ b/UsageStatistics_Sources_Redis.php
@@ -37,7 +37,10 @@ class UsageStatistics_Sources_Redis {
 				array(
 					'servers' => array( $host_port ),
 					'password' => $i['password'],
-					'dbid' => $i['dbid']
+					'dbid' => $i['dbid'],
+					'timeout' => 0,
+					'retry_interval' => 0,
+					'read_timeout' => 0,
 				) );
 
 			$stats = $cache->get_statistics();
@@ -74,7 +77,10 @@ class UsageStatistics_Sources_Redis {
 				array(
 					'servers' => array( $host_port ),
 					'password' => $i['password'],
-					'dbid' => $i['dbid']
+					'dbid' => $i['dbid'],
+					'timeout' => 0,
+					'retry_interval' => 0,
+					'read_timeout' => 0,
 				) );
 
 			$stats = $cache->get_statistics();
@@ -110,7 +116,10 @@ class UsageStatistics_Sources_Redis {
 				array(
 					'servers' => array( $host_port ),
 					'password' => $i['password'],
-					'dbid' => $i['dbid']
+					'dbid' => $i['dbid'],
+					'timeout' => 0,
+					'retry_interval' => 0,
+					'read_timeout' => 0,
 				) );
 
 			$stats = $cache->get_statistics();

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -30,13 +30,20 @@ if ( ! defined( 'W3TC' ) ) {
 		<p class="description"><?php esc_html_e( 'Multiple servers may be used and seperated by a comma; e.g. 192.168.1.100:11211, domain.com:22122. To use TLS, prefix server with tls://', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
-<tr class="hidden">
+<?php
+// PHP Redis 5.3.2+ supports SSL/TLS.
+if ( version_compare( phpversion( 'redis' ), '5.3.2', '>=' ) ) {
+?>
+<tr>
 	<th><label><?php esc_html_e( 'Verify TLS Certificates:', 'w3-total-cache' ); ?></label></th>
 	<td>
 		<?php $this->checkbox( $module . '.redis.verify_tls_certificates' ); ?> <?php echo wp_kses( Util_ConfigLabel::get( 'redis.verify_tls_certificates' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label>
 		<p class="description"><?php esc_html_e( 'Verify the server\'s certificate when connecting via TLS.', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
+<?php
+}
+?>
 <tr>
 	<th><label><?php esc_html_e( 'Use persistent connection:', 'w3-total-cache' ); ?></label></th>
 	<td>

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -33,15 +33,15 @@ if ( ! defined( 'W3TC' ) ) {
 <?php
 // PHP Redis 5.3.2+ supports SSL/TLS.
 if ( version_compare( phpversion( 'redis' ), '5.3.2', '>=' ) ) {
-?>
-<tr>
-	<th><label><?php esc_html_e( 'Verify TLS Certificates:', 'w3-total-cache' ); ?></label></th>
-	<td>
-		<?php $this->checkbox( $module . '.redis.verify_tls_certificates' ); ?> <?php echo wp_kses( Util_ConfigLabel::get( 'redis.verify_tls_certificates' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label>
-		<p class="description"><?php esc_html_e( 'Verify the server\'s certificate when connecting via TLS.', 'w3-total-cache' ); ?></p>
-	</td>
-</tr>
-<?php
+	?>
+	<tr>
+		<th><label><?php esc_html_e( 'Verify TLS Certificates:', 'w3-total-cache' ); ?></label></th>
+		<td>
+			<?php $this->checkbox( $module . '.redis.verify_tls_certificates' ); ?> <?php echo wp_kses( Util_ConfigLabel::get( 'redis.verify_tls_certificates' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label>
+			<p class="description"><?php esc_html_e( 'Verify the server\'s certificate when connecting via TLS.', 'w3-total-cache' ); ?></p>
+		</td>
+	</tr>
+	<?php
 }
 ?>
 <tr>
@@ -74,18 +74,18 @@ if ( version_compare( phpversion( 'redis' ), '5.3.2', '>=' ) ) {
 <?php
 // PHP Redis 3.1.3+ supports the read_timeout setting.
 if ( version_compare( phpversion( 'redis' ), '3.1.3', '>=' ) ) {
-?>
-<tr>
-	<th style="width: 250px;"><label for="redis_read_timeout"><?php echo wp_kses( Util_ConfigLabel::get( 'redis.read_timeout' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label></th>
-	<td>
-		<input id="redis_read_timeout" type="number" name="<?php echo esc_attr( $module ); ?>__redis__read_timeout"
-			<?php Util_Ui::sealing_disabled( $module ); ?>
-			value="<?php echo esc_attr( $this->_config->get_integer( $module . '.redis.read_timeout' ) ); ?>"
-			size="8" step="1" min="0" />
-		<p class="description"><?php esc_html_e( 'In seconds', 'w3-total-cache' ); ?></p>
-	</td>
-</tr>
-<?php
+	?>
+	<tr>
+		<th style="width: 250px;"><label for="redis_read_timeout"><?php echo wp_kses( Util_ConfigLabel::get( 'redis.read_timeout' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label></th>
+		<td>
+			<input id="redis_read_timeout" type="number" name="<?php echo esc_attr( $module ); ?>__redis__read_timeout"
+				<?php Util_Ui::sealing_disabled( $module ); ?>
+				value="<?php echo esc_attr( $this->_config->get_integer( $module . '.redis.read_timeout' ) ); ?>"
+				size="8" step="1" min="0" />
+			<p class="description"><?php esc_html_e( 'In seconds', 'w3-total-cache' ); ?></p>
+		</td>
+	</tr>
+	<?php
 }
 ?>
 <tr>

--- a/inc/options/parts/redis.php
+++ b/inc/options/parts/redis.php
@@ -65,9 +65,9 @@ if ( ! defined( 'W3TC' ) ) {
 	</td>
 </tr>
 <?php
-if ( version_compare( phpversion( 'redis' ), '5', '>=' ) ) {
-	// PHP Redis 5 supports the read_timeout setting.
-	?>
+// PHP Redis 3.1.3+ supports the read_timeout setting.
+if ( version_compare( phpversion( 'redis' ), '3.1.3', '>=' ) ) {
+?>
 <tr>
 	<th style="width: 250px;"><label for="redis_read_timeout"><?php echo wp_kses( Util_ConfigLabel::get( 'redis.read_timeout' ), array( 'acronym' => array( 'title' => array() ) ) ); ?></label></th>
 	<td>
@@ -78,7 +78,7 @@ if ( version_compare( phpversion( 'redis' ), '5', '>=' ) ) {
 		<p class="description"><?php esc_html_e( 'In seconds', 'w3-total-cache' ); ?></p>
 	</td>
 </tr>
-	<?php
+<?php
 }
 ?>
 <tr>

--- a/ini/config-db-sample.php
+++ b/ini/config-db-sample.php
@@ -1,35 +1,36 @@
 <?php
+/**
+ * File: config-db-sample.php
+ *
+ * @package W3TC
+ */
 
 define( 'W3TC_CONFIG_DATABASE', true );
 
-// optional - specify table to store
+// optional - specify table to store.
 define( 'W3TC_CONFIG_DATABASE_TABLE', 'wp_options' );
 
 // cache config in cache to prevent db queries on each http request.
 // if multiple http servers used - use only shared cache storage used by all
 // machines, since distributed flush operations are not supported for config
-// cache
+// cache.
 
-//
-// memcached cache config
-//
-define( 'W3TC_CONFIG_CACHE_ENGINE', 'memcached');
+// memcached cache config.
+define( 'W3TC_CONFIG_CACHE_ENGINE', 'memcached' );
 define( 'W3TC_CONFIG_CACHE_MEMCACHED_SERVERS', '127.0.0.1:11211' );
 
-// optional memcached settings
+// optional memcached settings.
 define( 'W3TC_CONFIG_CACHE_MEMCACHED_PERSISTENT', true );
 define( 'W3TC_CONFIG_CACHE_MEMCACHED_AWS_AUTODISCOVERY', false );
 define( 'W3TC_CONFIG_CACHE_MEMCACHED_USERNAME', '' );
 define( 'W3TC_CONFIG_CACHE_MEMCACHED_PASSWORD', '' );
 
-//
-// redis config cache
-//
-define( 'W3TC_CONFIG_CACHE_ENGINE', 'redis');
+// redis config cache.
+define( 'W3TC_CONFIG_CACHE_ENGINE', 'redis' );
 define( 'W3TC_CONFIG_CACHE_REDIS_SERVERS', '127.0.0.1:6379' );
-define( 'W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES', true);
+define( 'W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES', true );
 
-// optional redis settings
+// optional redis settings.
 define( 'W3TC_CONFIG_CACHE_REDIS_PERSISTENT', true );
 define( 'W3TC_CONFIG_CACHE_REDIS_DBID', 0 );
 define( 'W3TC_CONFIG_CACHE_REDIS_PASSWORD', '' );

--- a/ini/config-db-sample.php
+++ b/ini/config-db-sample.php
@@ -27,6 +27,7 @@ define( 'W3TC_CONFIG_CACHE_MEMCACHED_PASSWORD', '' );
 //
 define( 'W3TC_CONFIG_CACHE_ENGINE', 'redis');
 define( 'W3TC_CONFIG_CACHE_REDIS_SERVERS', '127.0.0.1:6379' );
+define( 'W3TC_CONFIG_CACHE_REDIS_VERIFY_TLS_CERTIFICATES', true);
 
 // optional redis settings
 define( 'W3TC_CONFIG_CACHE_REDIS_PERSISTENT', true );


### PR DESCRIPTION
**tl;dr:** This PR re-enables support for connecting to Redis servers using TLS with self-signed certificates. It also updates W3TC's "cache plugin config in redis" logic to support Redis servers with self-signed certificates. This updated implementation should now play nicely with older versions of `phpredis` and avoid generating [warnings about passing the wrong # of args to `pconnect`](https://github.com/W3EDGE/w3-total-cache/issues/533).

@KZeni If you're up for it, I'd love to have you test out this updated code with your setup that's using `phpredis 3.1.1`!

## Timeline:
1. [My previous PR](https://github.com/W3EDGE/w3-total-cache/pull/494) to add support for connecting to redis using TLS with self-signed certs (e.g., Heroku Redis) was accepted on April 28, 2022 ✅ 
2. Support for disabling TLS cert verification ships with W3TC v2.2.2 🎉 
3. It was removed in v2.2.3 https://github.com/W3EDGE/w3-total-cache/pull/526
   - some folks with older `phpredis` were getting [warnings about passing the wrong # of args to pconnect](https://github.com/W3EDGE/w3-total-cache/issues/533), so support for disabling TLS cert verification was removed + the corresponding plugin config UI for the option was hidden
4. You are here :)

This PR may be easier to review as a set of individual commits. I tried to make each commit stand on its own.

## This PR:
- e2482c778b87700fbb84afb48eb6f14b2a4ef832 Cleans up an extraneous call to `restore_error_handler` left over from a release candidate
- 0ffd86b521601915cd4563fc4786d491b4a1cc97 DRYs increasingly confusing logic for determining the redis connection args
- 874732b8465797685545a646340855aa15205bc3 Improves logic related to the `read_timeout` connection arg (it was added to `phpredis` in v3.1.3 not v5)
- a076c93187a726d90778960b6a4318093cddb5b0 **Re-enables support for disabling TLS cert verification**
- 238df91c86d37825c8709ed42da558c3b69fac73 Adds ability to disable TLS cert verification for the "cache plugin config in redis" logic
- 20ce726e56e6b089570ea7ec642d3aca7d87a5b4 Fixes up some odds and ends that use redis, but weren't respecting the "verify_tls_certificates" option

Related to #67