### PR TITLE
w3tcData is only for W3TC pages

### DIFF
--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -321,6 +321,10 @@ function w3tc_csp_reference() {
 }
 
 function cdn_cf_check() {
+	if ( typeof w3tcData === 'undefined' ) {
+		return;
+	}
+
 	var cdnEnabled = jQuery( '#cdn__enabled' ).is( ':checked' ),
 		cdnEngine = jQuery( '#cdn__engine' ).find( ':selected' ).val(),
 		cdnFlushManually = jQuery( '[name="cdn__flush_manually"]' ).is( ':checked' );


### PR DESCRIPTION
In reference to https://wordpress.org/support/topic/console-errors-23/

A function in `options.js` is run on non-plugin pages that expect `w3Data` to be defined.

1. Enable "Amazon Simple Storage Service (S3)" as a CDN at `wp-admin/admin.php?page=w3tc_general#cdn`.
2. Open the browser web console.
3. Go to the WordPress Plugins page -- `wp-admin/plugins.php`
4. Check for an error "Uncaught ReferenceError: w3tcData is not defined".
