### PR TITLE
Pagecache unpack fix 

### DIFF
--- a/Cache_File.php
+++ b/Cache_File.php
@@ -156,8 +156,9 @@ class Cache_File extends Cache_Base {
 			return array( null, $has_old_data );
 
 		$fp = @fopen( $path, 'rb' );
-		if ( !$fp )
+		if ( ! $fp || 4 > filesize( $path ) ) {
 			return array( null, $has_old_data );
+		}
 
 		if ( $this->_locking )
 			@flock( $fp, LOCK_SH );


### PR DESCRIPTION
Resolves warnings/errors thrown for unpack for files that are either empty or contain less than 4 bytes of data. Cached files are expected to contain at least 4 bytes of data at start that represent the cache expire time

`Warning (2): unpack(): Type L: not enough input, need 4, have 0`

**NOTE** : Unable to replicate specific error but in debugging I determined that empty/malformed files were being processed despite the malformed data