### PR TITLE
Several filesystem related fixes for when WP_HOME is set.

### DIFF
--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -50,7 +50,7 @@ class BrowserCache_Environment_Nginx {
 					$home_uri = W3TC_HOME_URI;
 				} else {
 					$primary_blog_id = get_network()->site_id;
-					$home_uri = parse_url( get_home_url( $primary_blog_id ),
+					$home_uri = parse_url( get_site_url( $primary_blog_id ),
 						PHP_URL_PATH );
 					$home_uri = rtrim( $home_uri, '/' );
 				}

--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -313,7 +313,7 @@ class Cdn_AdminActions {
 		$title = __( 'Content Delivery Network (CDN): Purge Tool', 'w3-total-cache' );
 		$results = array();
 
-		$path = ltrim( str_replace( get_home_url(), '', get_stylesheet_directory_uri() ), '/' );
+		$path = ltrim( str_replace( get_site_url(), '', get_stylesheet_directory_uri() ), '/' );
 		include W3TC_INC_DIR . '/popup/cdn_purge.php';
 	}
 
@@ -345,7 +345,7 @@ class Cdn_AdminActions {
 			$errors[] = __( 'Empty files list.', 'w3-total-cache' );
 		}
 
-		$path = str_replace( get_home_url(), '', get_stylesheet_directory_uri() );
+		$path = str_replace( get_site_url(), '', get_stylesheet_directory_uri() );
 		include W3TC_INC_DIR . '/popup/cdn_purge.php';
 	}
 

--- a/Generic_AdminActions_Config.php
+++ b/Generic_AdminActions_Config.php
@@ -51,7 +51,7 @@ class Generic_AdminActions_Config {
 	 * @return void
 	 */
 	function w3tc_config_export() {
-		$filename = substr( get_home_url(), strpos( get_home_url(), '//' )+2 );
+		$filename = substr( get_site_url(), strpos( get_site_url(), '//' )+2 );
 		@header( sprintf( __( 'Content-Disposition: attachment; filename=%s.json', 'w3-total-cache' ), $filename ) );
 		echo $this->_config->export(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		die();

--- a/Util_Rule.php
+++ b/Util_Rule.php
@@ -395,7 +395,7 @@ class Util_Rule {
 		case Util_Environment::is_apache():
 		case Util_Environment::is_litespeed():
 			if ( Util_Environment::is_wpmu() ) {
-				$url = get_home_url();
+				$url = get_site_url();
 				$match = null;
 				if ( preg_match( '~http(s)?://(.+?)(/)?$~', $url, $match ) ) {
 					$home_path = $match[2];


### PR DESCRIPTION
This is an extension of the fix for 568. I found several other uses of wp_home_url for file-system related items that would likely break if WP_HOME was set. This needs testing under relevant environments for each "fix"

Additionally there are still a decent number of wp_home_url calls in the codebase but as far as I can tell these are either used in URL manipulations or as display values unrelated to file paths