### PR TITLE
Fix for scheduled posts not flushing PgCache

### DIFF
--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -23,8 +23,8 @@ class Util_AttachToActions {
 
 		// posts.
 		add_action( 'pre_post_update', array( $o, 'on_pre_post_update' ), 0, 2 );
-		add_action( 'pre_trash_post', array( $o, 'on_post_change' ), 0, 2 );
 		add_action( 'save_post', array( $o, 'on_post_change' ), 0, 2 );
+		add_action( 'wp_trash_post', array( $o, 'on_post_change' ), 0, 2 );
 
 		// comments.
 		add_action( 'comment_post', array( $o, 'on_comment_change' ), 0 );

--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -6,100 +6,101 @@ namespace W3TC;
  * flushes of html content
  */
 class Util_AttachToActions {
-	static function flush_posts_on_actions() {
+	/**
+	 * Flush actions.
+	 *
+	 * @return void
+	 */
+	public static function flush_posts_on_actions() {
 		static $attached = false;
-		if ( $attached )
+		if ( $attached ) {
 			return;
+		}
 
 		$attached = true;
 
 		$o = new Util_AttachToActions();
 
-		add_action( 'clean_post_cache', array(
-				$o,
-				'on_post_change'
-			), 0, 2 );
+		// posts.
+		add_action( 'save_post', array( $o, 'on_post_change' ), 0, 2 );
+		add_action( 'delete_post', array( $o, 'on_post_change' ), 0, 2 );
 
-		// when post status is changed to draft - it looses its URL
-		// so we need to flush before update is happened
-		add_action( 'pre_post_update', array(
-				$o,
-				'on_post_change'
-			), 0 );
-		add_action( 'wp_trash_post', array(
-				$o,
-				'on_post_change'
-			), 0 );
+		// comments.
+		add_action( 'comment_post', array( $o, 'on_comment_change' ), 0 );
+		add_action( 'edit_comment', array( $o, 'on_comment_change' ), 0 );
+		add_action( 'delete_comment', array( $o, 'on_comment_change' ), 0 );
+		add_action( 'wp_set_comment_status', array( $o, 'on_comment_status' ), 0, 2 );
+		add_action( 'trackback_post', array( $o, 'on_comment_change' ), 0 );
+		add_action( 'pingback_post', array( $o, 'on_comment_change' ), 0 );
 
-		add_action( 'publish_post', array(
-				$o,
-				'on_post_change'
-			), 0, 2 );
+		// theme.
+		add_action( 'switch_theme', array( $o, 'on_change' ), 0 );
 
-		add_action( 'switch_theme', array(
-				$o,
-				'on_change'
-			), 0 );
+		// navigation menu.
+		add_action( 'wp_update_nav_menu', array( $o, 'on_change' ), 0 );
 
-		add_action( 'wp_update_nav_menu', array(
-				$o,
-				'on_change'
-			), 0 );
+		// user profile.
+		add_action( 'edit_user_profile_update', array( $o, 'on_change' ), 0 );
 
-		add_action( 'edit_user_profile_update', array(
-				$o,
-				'on_change'
-			), 0 );
+		// terms.
+		add_action( 'edited_term', array( $o, 'on_change' ), 0 );
+		add_action( 'delete_term', array( $o, 'on_change' ), 0 );
 
+		// multisite.
 		if ( Util_Environment::is_wpmu() ) {
-			add_action( 'delete_blog', array(
-					$o,
-					'on_change'
-				), 0 );
+			add_action( 'delete_blog', array( $o, 'on_change' ), 0 );
 		}
-
-		add_action( 'edited_term', array(
-				$o,
-				'on_change'
-			), 0 );
 	}
-
-
 
 	/**
 	 * Post changed action
 	 *
-	 * @param integer $post_id
-	 * @param null    $post
+	 * @param integer $post_id Post ID.
+	 * @param null    $post    Post.
 	 * @return void
 	 */
-	function on_post_change( $post_id, $post = null ) {
-		if ( is_null( $post ) )
-			$post = get_post( $post_id );
-
-		// if attachment changed - parent post has to be flushed
-		// since there are usually attachments content like title
-		// on the page (gallery)
-		if ( $post->post_type == 'attachment' ) {
-			$post_id = $post->post_parent;
+	public function on_post_change( $post_id, $post = null ) {
+		if ( is_null( $post ) ) {
 			$post = get_post( $post_id );
 		}
 
-		if ( !Util_Environment::is_flushable_post( $post, 'posts',
-				Dispatcher::config() ) )
+		// if attachment changed - parent post has to be flushed
+		// since there are usually attachments content like title
+		// on the page (gallery).
+		if ( 'attachment' === $post->post_type ) {
+			$post_id = $post->post_parent;
+			$post    = get_post( $post_id );
+		}
+
+		if ( ! Util_Environment::is_flushable_post( $post, 'posts', Dispatcher::config() ) ) {
 			return;
+		}
 
 		$cacheflush = Dispatcher::component( 'CacheFlush' );
 		$cacheflush->flush_post( $post_id );
 	}
 
+	/**
+	 * Comment change action
+	 *
+	 * @param integer $comment_id Comment ID.
+	 */
+	public function on_comment_change( $comment_id ) {
+		$post_id = 0;
 
+		if ( $comment_id ) {
+			$comment = get_comment( $comment_id, ARRAY_A );
+			$post_id = ( ! empty( $comment['comment_post_ID'] ) ? (int) $comment['comment_post_ID'] : 0 );
+		}
+
+		$this->on_post_change( $post_id );
+	}
 
 	/**
 	 * Change action
 	 */
-	function on_change() {
-		$cacheFlush = Dispatcher::component( 'CacheFlush' );
-		$cacheFlush->flush_posts();
+	public function on_change() {
+		$cacheflush = Dispatcher::component( 'CacheFlush' );
+		$cacheflush->flush_posts();
 	}
 }


### PR DESCRIPTION
This is a compound issue between the original hooks used by Page Cache not applying uniformly between regular pages/posts and custom post types and the Object Cache caching cron jobs and preventing them from executing

This PR changes the hooks so that CPTs are fully supported. A separate PR will address the Object Cache correlated issue