### PR TITLE
Fixed infinite loop when disabling minify HTTP2/push setting

### DIFF
--- a/Generic_AdminActions_Default.php
+++ b/Generic_AdminActions_Default.php
@@ -286,7 +286,6 @@ class Generic_AdminActions_Default {
 		if ( 'w3tc_minify' === $this->_page ) {
 			if ( ( $this->_config->get_boolean( 'minify.js.http2push' ) && ! $config->get_boolean( 'minify.js.http2push' ) ) ||
 			( $this->_config->get_boolean( 'minify.css.http2push' ) && ! $config->get_boolean( 'minify.css.http2push' ) ) ) {
-
 				if ( 'file_generic' === $config->get_string( 'pgcache.engine' ) ) {
 					$cache_dir = Util_Environment::cache_blog_dir( 'page_enhanced' );
 					$this->_delete_all_htaccess_files( $cache_dir );
@@ -577,8 +576,7 @@ class Generic_AdminActions_Default {
 			return;
 		}
 
-		$file = readdir( $handle );
-		while ( false !== $file ) {
+		while ( false !== ( $file = readdir( $handle ) ) ) {
 			if ( '.' === $file || '..' === $file ) {
 				continue;
 			}
@@ -587,7 +585,7 @@ class Generic_AdminActions_Default {
 				$this->_delete_all_htaccess_files( $file );
 				continue;
 			} elseif ( '.htaccess' === $file ) {
-				@unlink( $file );
+				@unlink( $dir . '/' . $file );
 			}
 		}
 


### PR DESCRIPTION
To replicate simply enable minify, navigate to the minify settings page and disable the HTTP2/push setting. Either save button should result in an infinite loop that results in a "max execution time" error