### PR TITLE
Fix top-bar purge "current page" link when PageCache purge policy disabled

### DIFF
--- a/CacheFlush_Locally.php
+++ b/CacheFlush_Locally.php
@@ -149,11 +149,15 @@ class CacheFlush_Locally {
 
 	/**
 	 * Purges/Flushes post from page cache, varnish and cdn cache
+	 *
+	 * @param integer $post_id Post ID.
+	 * @param boolean $force   Force flag (optional).
+	 * @param array   $extras  Extras.
 	 */
-	function flush_post( $post_id, $extras = null ) {
+	function flush_post( $post_id, $force = false, $extras = null ) {
 		$do_flush = apply_filters( 'w3tc_preflush_post', true, $extras );
 		if ( $do_flush )
-			do_action( 'w3tc_flush_post', $post_id, $extras );
+			do_action( 'w3tc_flush_post', $post_id, $force, $extras );
 	}
 
 	/**

--- a/Cdnfsd_CacheFlush.php
+++ b/Cdnfsd_CacheFlush.php
@@ -57,11 +57,12 @@ class Cdnfsd_CacheFlush {
 	 * Purges cdn's post cache
 	 *
 	 * @param integer $post_id Post ID.
-	 * @param array   $extras Extras.
+	 * @param boolean $force   Force Flag (optional).
+	 * @param array   $extras  Extras.
 	 *
 	 * @return bool
 	 */
-	public static function w3tc_flush_post( $post_id, $extras = null ) {
+	public static function w3tc_flush_post( $post_id, $force = false, $extras = null ) {
 		if ( ! $post_id ) {
 			$post_id = Util_Environment::detect_post_id();
 		}
@@ -122,7 +123,7 @@ class Cdnfsd_CacheFlush {
 		}
 
 		// Post URL.
-		if ( $config->get_boolean( 'pgcache.purge.post' ) ) {
+		if ( $config->get_boolean( 'pgcache.purge.post' ) || $force ) {
 			$full_urls = array_merge( $full_urls, Util_PageUrls::get_post_urls( $post_id ) );
 		}
 

--- a/Cdnfsd_Plugin.php
+++ b/Cdnfsd_Plugin.php
@@ -36,7 +36,7 @@ class Cdnfsd_Plugin {
 		add_action( 'w3tc_flush_post', array(
 				'\W3TC\Cdnfsd_CacheFlush',
 				'w3tc_flush_post'
-			), 3000, 2 );
+			), 3000, 3 );
 		add_action( 'w3tc_flushable_posts', '__return_true', 3000 );
 		add_action( 'w3tc_flush_posts', array(
 				'\W3TC\Cdnfsd_CacheFlush',

--- a/Cli.php
+++ b/Cli.php
@@ -133,7 +133,7 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 				if ( isset( $vars['post_id'] ) ) {
 					if ( is_numeric( $vars['post_id'] ) ) {
 						try {
-							w3tc_flush_post( $vars['post_id'] );
+							w3tc_flush_post( $vars['post_id'], true );
 						}
 						catch ( \Exception $e ) {
 							\WP_CLI::error( __( 'Flushing the page from cache failed.', 'w3-total-cache' ) );

--- a/Generic_AdminActions_Flush.php
+++ b/Generic_AdminActions_Flush.php
@@ -245,7 +245,7 @@ class Generic_AdminActions_Flush {
 	 */
 	function w3tc_flush_post() {
 		$post_id = Util_Request::get_integer( 'post_id' );
-		w3tc_flush_post( $post_id, array( 'ui_action' => 'flush_button' ) );
+		w3tc_flush_post( $post_id, true, array( 'ui_action' => 'flush_button' ) );
 
 		Util_Admin::redirect( array(
 				'w3tc_note' => 'pgcache_purge_post'

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -267,7 +267,7 @@ class Generic_Plugin {
 						'parent' => 'w3tc',
 						'title'  => __( 'Purge Current Page', 'w3-total-cache' ),
 						'href'   => wp_nonce_url(
-							admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_post&amp;post_id=' . Util_Environment::detect_post_id() ),
+							admin_url( 'admin.php?page=w3tc_dashboard&amp;w3tc_flush_post&amp;post_id=' . Util_Environment::detect_post_id() . '&force=true' ),
 							'w3tc'
 						),
 					);

--- a/Generic_Plugin_AdminRowActions.php
+++ b/Generic_Plugin_AdminRowActions.php
@@ -33,7 +33,7 @@ class Generic_Plugin_AdminRowActions {
 
 		if ( current_user_can( $capability ) )
 			$actions = array_merge( $actions, array(
-					'w3tc_flush_post' => sprintf( '<a href="%s">' . __( 'Purge from cache', 'w3-total-cache' ) . '</a>', wp_nonce_url( sprintf( 'admin.php?page=w3tc_dashboard&w3tc_flush_post&post_id=%d', $post->ID ), 'w3tc' ) )
+					'w3tc_flush_post' => sprintf( '<a href="%s">' . __( 'Purge from cache', 'w3-total-cache' ) . '</a>', wp_nonce_url( sprintf( 'admin.php?page=w3tc_dashboard&w3tc_flush_post&post_id=%d&force=true', $post->ID ), 'w3tc' ) )
 				) );
 
 		return $actions;
@@ -52,7 +52,7 @@ class Generic_Plugin_AdminRowActions {
 
 		if ( current_user_can( $capability ) )
 			$actions = array_merge( $actions, array(
-					'w3tc_flush_post' => sprintf( '<a href="%s">' . __( 'Purge from cache', 'w3-total-cache' ) . '</a>', wp_nonce_url( sprintf( 'admin.php?page=w3tc_dashboard&w3tc_flush_post&post_id=%d', $post->ID ), 'w3tc' ) )
+					'w3tc_flush_post' => sprintf( '<a href="%s">' . __( 'Purge from cache', 'w3-total-cache' ) . '</a>', wp_nonce_url( sprintf( 'admin.php?page=w3tc_dashboard&w3tc_flush_post&post_id=%d&force=true', $post->ID ), 'w3tc' ) )
 				) );
 
 		return $actions;
@@ -65,9 +65,14 @@ class Generic_Plugin_AdminRowActions {
 		if ( current_user_can( 'manage_options' ) ) {
 			global $post;
 			if ( !is_null( $post ) ) {
-				$url = Util_Ui::url( array( 'page' => 'w3tc_dashboard',
+				$url = Util_Ui::url(
+					array(
+						'page'            => 'w3tc_dashboard',
 						'w3tc_flush_post' => 'y',
-						'post_id' => $post->ID ) );
+						'post_id'         => $post->ID,
+						'force'           => true,
+					)
+				);
 
 				echo sprintf(
 					'<div><a href="%s">%s</a></div>',

--- a/PgCache_Flush.php
+++ b/PgCache_Flush.php
@@ -42,9 +42,10 @@ class PgCache_Flush extends PgCache_ContentGrabber {
 	/**
 	 * Flushes post cache
 	 *
-	 * @param integer $post_id
+	 * @param integer $post_id Post ID.
+	 * @param boolean $force   Force flag (optional).
 	 */
-	public function flush_post( $post_id = null ) {
+	public function flush_post( $post_id = null, $force = false ) {
 		if ( !$post_id ) {
 			$post_id = Util_Environment::detect_post_id();
 		}
@@ -124,7 +125,7 @@ class PgCache_Flush extends PgCache_ContentGrabber {
 		}
 
 		// Post URL
-		if ( $this->_config->get_boolean( 'pgcache.purge.post' ) ) {
+		if ( $this->_config->get_boolean( 'pgcache.purge.post' ) || $force ) {
 			$full_urls = array_merge( $full_urls,
 				Util_PageUrls::get_post_urls( $post_id ) );
 		}

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -392,7 +392,7 @@ class PgCache_Plugin {
 	 *
 	 * @return boolean
 	 */
-	public function w3tc_flush_post( $post_id, $force ) {
+	public function w3tc_flush_post( $post_id, $force = false ) {
 		$pgcacheflush = Dispatcher::component( 'PgCache_Flush' );
 		$v            = $pgcacheflush->flush_post( $post_id, $force );
 

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -33,7 +33,7 @@ class PgCache_Plugin {
 	public function run() {
 		add_action( 'w3tc_flush_all', array( $this, 'w3tc_flush_posts' ), 1100, 1 );
 		add_action( 'w3tc_flush_group', array( $this, 'w3tc_flush_group' ), 1100, 2 );
-		add_action( 'w3tc_flush_post', array( $this, 'w3tc_flush_post' ), 1100, 1 );
+		add_action( 'w3tc_flush_post', array( $this, 'w3tc_flush_post' ), 1100, 2 );
 		add_action( 'w3tc_flushable_posts', '__return_true', 1100 );
 		add_action( 'w3tc_flush_posts', array( $this, 'w3tc_flush_posts' ), 1100 );
 		add_action( 'w3tc_flush_url', array( $this, 'w3tc_flush_url' ), 1100, 1 );
@@ -339,7 +339,7 @@ class PgCache_Plugin {
 				'href'   => wp_nonce_url(
 					admin_url(
 						'admin.php?page=w3tc_dashboard&amp;w3tc_flush_post&amp;post_id=' .
-							Util_Environment::detect_post_id()
+							Util_Environment::detect_post_id() . '&amp;force=true'
 					),
 					'w3tc'
 				),
@@ -388,12 +388,13 @@ class PgCache_Plugin {
 	 * Flushes post cache
 	 *
 	 * @param integer $post_id Post ID.
+	 * @param boolean $force   Force flag (optional).
 	 *
 	 * @return boolean
 	 */
-	public function w3tc_flush_post( $post_id ) {
+	public function w3tc_flush_post( $post_id, $force ) {
 		$pgcacheflush = Dispatcher::component( 'PgCache_Flush' );
-		$v            = $pgcacheflush->flush_post( $post_id );
+		$v            = $pgcacheflush->flush_post( $post_id, $force );
 
 		return $v;
 	}

--- a/Varnish_Flush.php
+++ b/Varnish_Flush.php
@@ -241,10 +241,12 @@ class Varnish_Flush {
 	/**
 	 * Flushes varnish post cache
 	 *
-	 * @param integer $post_id
+	 * @param integer $post_id Post ID.
+	 * @param boolean $force   Force flag (optional).
+	 *
 	 * @return boolean
 	 */
-	function flush_post( $post_id ) {
+	function flush_post( $post_id, $force ) {
 		if ( !$post_id ) {
 			$post_id = Util_Environment::detect_post_id();
 		}
@@ -294,7 +296,7 @@ class Varnish_Flush {
 			/**
 			 * Post URL
 			 */
-			if ( $this->_config->get_boolean( 'pgcache.purge.post' ) ) {
+			if ( $this->_config->get_boolean( 'pgcache.purge.post' ) || $force ) {
 				$full_urls = array_merge( $full_urls, Util_PageUrls::get_post_urls( $post_id ) );
 			}
 

--- a/Varnish_Plugin.php
+++ b/Varnish_Plugin.php
@@ -16,7 +16,7 @@ class Varnish_Plugin {
 			2000, 1 );
 		add_action( 'w3tc_flush_post',
 			array( $this, 'varnish_flush_post' ),
-			2000, 1 );
+			2000, 2 );
 		add_action( 'w3tc_flushable_posts', '__return_true', 2000 );
 		add_action( 'w3tc_flush_posts',
 			array( $this, 'varnish_flush' ),
@@ -49,12 +49,14 @@ class Varnish_Plugin {
 	/**
 	 * Purges post from varnish
 	 *
-	 * @param integer $post_id
+	 * @param integer $post_id Post ID.
+	 * @param boolean $force   Force flag (optional).
+	 *
 	 * @return mixed
 	 */
-	public function varnish_flush_post( $post_id ) {
+	public function varnish_flush_post( $post_id, $force ) {
 		$varnishflush = Dispatcher::component( 'Varnish_Flush' );
-		$v = $varnishflush->flush_post( $post_id );
+		$v = $varnishflush->flush_post( $post_id, $force );
 
 		return $v;
 	}

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -270,12 +270,13 @@ function w3tc_flush_all( $extras = null ) {
 /**
  * Purges/Flushes post page.
  *
- * @param int   $post_id Post id.
- * @param array $extras  Exteas.
+ * @param int     $post_id Post id.
+ * @param boolean $force   Force flag (optional).
+ * @param array   $extras  Extras.
  */
-function w3tc_flush_post( $post_id, $extras = null ) {
+function w3tc_flush_post( $post_id, $force = false, $extras = null ) {
 	$o = \W3TC\Dispatcher::component( 'CacheFlush' );
-	$o->flush_post( $post_id, $extras );
+	$o->flush_post( $post_id, $force, $extras );
 }
 
 /**
@@ -324,11 +325,13 @@ function w3tc_pgcache_flush() {
 /**
  * Deprecated.  Shortcut for page post cache flush.
  *
- * @param int $post_id Post id.
+ * @param int     $post_id Post id.
+ * @param boolean $force Force flag (optional).
+ *
  * @return bool
  */
-function w3tc_pgcache_flush_post( $post_id ) {
-	return w3tc_flush_post( $post_id );
+function w3tc_pgcache_flush_post( $post_id, $force = false ) {
+	return w3tc_flush_post( $post_id, $force );
 }
 
 /**


### PR DESCRIPTION
To replicate simply disable all Purge Policy: Page Cache options under the Page Cache settings page with PageCache enabled. This will cause the top-bar menu item for Purge Modules > Page Cache: Current Page to fail to flush the given page/post