### PR TITLE
Added missing PgCache configuration "host" value

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -932,9 +932,9 @@ class PgCache_ContentGrabber {
 			}
 
 			$engineConfig['use_expired_data'] = true;
-			$engineConfig['module'] = 'pgcache';
-			$engineConfig['host'] = '';   // host is always put to a key
-			$engineConfig['instance_id'] = Util_Environment::instance_id();
+			$engineConfig['module']           = 'pgcache';
+			$engineConfig['host']             = Util_Environment::host();
+			$engineConfig['instance_id']      = Util_Environment::instance_id();
 
 			$caches[$group] = Cache::instance( $engine, $engineConfig );
 		}


### PR DESCRIPTION
This applies to any configuration/engine of PgCache and doesn't appear to have any negative impact with or without this "fix". It appears to be an inconsequential configuration value in operation