### PR TITLE
Potential fix for parameter count fatal PHP error when using Varnish

### DIFF
--- a/Varnish_Plugin.php
+++ b/Varnish_Plugin.php
@@ -54,7 +54,7 @@ class Varnish_Plugin {
 	 *
 	 * @return mixed
 	 */
-	public function varnish_flush_post( $post_id, $force ) {
+	public function varnish_flush_post( $post_id, $force = false ) {
 		$varnishflush = Dispatcher::component( 'Varnish_Flush' );
 		$v = $varnishflush->flush_post( $post_id, $force );
 


### PR DESCRIPTION
The issue occurs when a post is created or modified, and the users has the reverse proxy Varnish setting enabled with Varnish installed and configured