### PR TITLE
Fix for missing on_comment_status class method.

### DIFF
--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -132,6 +132,18 @@ class Util_AttachToActions {
 	}
 
 	/**
+	 * Comment status action
+	 *
+	 * @param integer $comment_id Comment ID.
+	 * @param string  $status Status.
+	 */
+	public function on_comment_status( $comment_id, $status ) {
+		if ( 'approve' === $status || '1' === $status ) {
+			$this->on_comment_change( $comment_id );
+		}
+	}
+
+	/**
 	 * Change action
 	 */
 	public function on_change() {

--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -138,9 +138,7 @@ class Util_AttachToActions {
 	 * @param string  $status Status.
 	 */
 	public function on_comment_status( $comment_id, $status ) {
-		if ( 'approve' === $status || '1' === $status ) {
-			$this->on_comment_change( $comment_id );
-		}
+		$this->on_comment_change( $comment_id );
 	}
 
 	/**


### PR DESCRIPTION
To test this simply enable page-cache and navigate to the Comments admin page /wp-admin/edit-comments.php. Then use the quick-links under a given comment to approve/spam/trash the given comment. This should trigger the wp_set_comment_status hook and in turn flush the associated post/feed