### PR TITLE
Added deprecation/migration admin notice for users utilizing MaxCDN

### DIFF
--- a/Cdn_AdminNotes.php
+++ b/Cdn_AdminNotes.php
@@ -11,12 +11,13 @@ class Cdn_AdminNotes {
 	 * @return array
 	 */
 	public function w3tc_notes( $notes ) {
-		$config = Dispatcher::config();
-		$state = Dispatcher::config_state();
-
+		$config     = Dispatcher::config();
+		$state      = Dispatcher::config_state();
+		$cdn_engine = $config->get_string( 'cdn.engine' );
+		
 		$page = Util_Request::get_string( 'page' );
 
-		if ( !Cdn_Util::is_engine_mirror( $config->get_string( 'cdn.engine' ) ) ) {
+		if ( !Cdn_Util::is_engine_mirror( $cdn_engine ) ) {
 			/**
 			 * Show notification after theme change
 			 */
@@ -121,6 +122,18 @@ class Cdn_AdminNotes {
 						'w3tc_default_config_state' => 'y',
 						'key' => 'cdn.hide_note_no_curl',
 						'value' => 'true' ) ) );
+		}
+
+		if ( 'maxcdn' === $cdn_engine ) {
+			$notes[] = sprintf(
+				// translators: 1 opening HTML a tag to MaxCDN/StackPath migration guide, 2 closing HTML a tag. 
+				__(
+					'MaxCDN is deprecated and is now StackPath CDN. As a result your MaxCDN configuration is now invalidated and will require either a reconfiguration under a new CDN provider or a migration to StackPath via %1$sthis%2$s guide.',
+					'w3-total-cache'
+				),
+				'<a href="https://support.stackpath.com/hc/en-us/articles/10408946467739-MaxCDN-Migration-to-StackPath-Instructions" target="_blank">',
+				'</a>'
+			);
 		}
 
 		return $notes;

--- a/Cdn_AdminNotes.php
+++ b/Cdn_AdminNotes.php
@@ -14,7 +14,7 @@ class Cdn_AdminNotes {
 		$config     = Dispatcher::config();
 		$state      = Dispatcher::config_state();
 		$cdn_engine = $config->get_string( 'cdn.engine' );
-		
+
 		$page = Util_Request::get_string( 'page' );
 
 		if ( !Cdn_Util::is_engine_mirror( $cdn_engine ) ) {
@@ -126,13 +126,14 @@ class Cdn_AdminNotes {
 
 		if ( 'maxcdn' === $cdn_engine ) {
 			$notes[] = sprintf(
-				// translators: 1 opening HTML a tag to MaxCDN/StackPath migration guide, 2 closing HTML a tag. 
+				// translators: 1: Opening anchor tag with a link to the CDN settings page, 2: closing anchor tag, 3 opening anchor tag to MaxCDN/StackPath migration guide.
 				__(
-					'MaxCDN is deprecated and is now StackPath CDN. As a result your MaxCDN configuration is now invalidated and will require either a reconfiguration under a new CDN provider or a migration to StackPath via %1$sthis%2$s guide.',
+					'MaxCDN has been replaced with StackPath CDN. As a result your configuration is now invalid and requires reconfiguration to a new %1$sCDN provider%2$s. You can migrate to StackPath using %3$sthis guide%2$s.',
 					'w3-total-cache'
 				),
-				'<a href="https://support.stackpath.com/hc/en-us/articles/10408946467739-MaxCDN-Migration-to-StackPath-Instructions" target="_blank">',
-				'</a>'
+				'<a href="' . esc_url( admin_url( 'admin.php?page=w3tc_general#cdn' ) ) . '">',
+				'</a>',
+				'<a href="' . esc_url( 'https://support.stackpath.com/hc/en-us/articles/10408946467739-MaxCDN-Migration-to-StackPath-Instructions' ) . '" target="_blank">'
 			);
 		}
 

--- a/Generic_Plugin_Admin.php
+++ b/Generic_Plugin_Admin.php
@@ -1108,8 +1108,9 @@ class Generic_Plugin_Admin {
 					),
 					'p'     => array(),
 					'a'     => array(
-						'href'  => array(),
-						'class' => array(),
+						'target' => array(),
+						'href'   => array(),
+						'class'  => array(),
 					),
 				)
 			);


### PR DESCRIPTION
Due to the fact that MaxCDN is now removed this notice will only show for users that previously configured their CDN as 'maxcdn'. The notice will inform them of the deprecation and provide a link to migrate to StackPath

One way to test is to modify Cdn_AdminNotes.php and add to line 126
`$cdn_engine = 'maxcdn';`

This should display the notice. Updating the CDN configuration to another CDN and removing the above added line should remove the notice