### PR TITLE
Fixed evaluations resulting in warnings/errors for non-existent values.

### DIFF
--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -71,12 +71,12 @@ class Util_AttachToActions {
 		// if attachment changed - parent post has to be flushed
 		// since there are usually attachments content like title
 		// on the page (gallery).
-		if ( 'attachment' === $data['post_type'] ) {
+		if ( isset( $data['post_type'] ) && 'attachment' === $data['post_type'] ) {
 			$post_id = $data['post_parent'];
 			$data    = get_post( $post_id, ARRAY_A );
 		}
 
-		if ( 'draft' !== $data['post_status'] ) {
+		if ( ! isset( $data['post_status'] ) || 'draft' !== $data['post_status'] ) {
 			return;
 		}
 
@@ -102,7 +102,7 @@ class Util_AttachToActions {
 		// if attachment changed - parent post has to be flushed
 		// since there are usually attachments content like title
 		// on the page (gallery).
-		if ( 'attachment' === $post->post_type ) {
+		if ( isset( $post->post_type ) && 'attachment' === $post->post_type ) {
 			$post_id = $post->post_parent;
 			$post    = get_post( $post_id );
 		}


### PR DESCRIPTION
We were unable to replicate this within the context of a test website, but were able to generate warnings by either manually modifying Util_AttachToActions.php line 78:

`unset($data['post_status']);`

or by CLI testing using:

```
/opt/cpanel/ea-php81/root/bin/php -r '$a = array( "test" => "yes" ); var_dump( $a["nope"] === "yes" );' -d display_errors=on

Warning: Undefined array key "nope" in Command line code on line 1
bool(false)
```

See https://wordpress.org/support/topic/regression-error-on-image-upload-when-memcached-is-enabled/ for reference.