### PR TITLE
Fix php 8.2 depreciations

### DIFF
--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -353,7 +353,7 @@ class BrowserCache_Environment_Nginx {
 		$lifetime = $this->c->get_integer( "browsercache.$section.lifetime" );
 
 		if ( $expires ) {
-			$rules[] = "expires ${lifetime}s;";
+			$rules[] = 'expires ' . $lifetime . 's;';
 		}
 		if ( version_compare( Util_Environment::get_server_version(), '1.3.3', '>=' ) ) {
 			if ( $this->c->get_boolean( "browsercache.$section.etag" ) ) {

--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -432,7 +432,7 @@ class Minify_Environment {
 				$rules .= "    RewriteCond %{REQUEST_FILENAME} !-f\n";
 			}
 		}
-		$rules .= "    RewriteRule ^(.+\\.(css|js))$ ${site_uri}index.php [L]\n";
+		$rules .= "    RewriteRule ^(.+\\.(css|js))$ {$site_uri}index.php [L]\n";
 
 		$rules .= "</IfModule>\n";
 		$rules .= W3TC_MARKER_END_MINIFY_CORE . "\n";
@@ -497,7 +497,7 @@ class Minify_Environment {
 			$rules .= "    rewrite (.*) $1\$w3tc_enc break;\n";
 			$rules .= "}\n";
 		}
-		$rules .= "rewrite ^$cache_uri ${minify_uri}index.php last;\n";
+		$rules .= "rewrite ^$cache_uri {$minify_uri}index.php last;\n";
 		$rules .= W3TC_MARKER_END_MINIFY_CORE . "\n";
 
 		return $rules;


### PR DESCRIPTION
Fixes:
- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /sites/en/wordpress/web/app/plugins/w3-total-cache/Minify_Environment.php on line 430
- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /sites/en/wordpress/web/app/plugins/w3-total-cache/Minify_Environment.php on line 495

(line numbers are for latest release 2.2.12)