### PR TITLE
Implemented Permissions-Policy

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -468,17 +468,23 @@ class BrowserCache_Environment {
 			if ( $config->get_boolean( 'browsercache.security.fp' ) ) {
 				$fp_values = $config->get_array( 'browsercache.security.fp.values' );
 
-				$v = array();
+				$feature_v    = array();
+				$permission_v = array();
 				foreach ( $fp_values as $key => $value ) {
-					$value = str_replace( '"', "'", $value );
-					if ( !empty( $value ) ) {
-						$v[] = "$key $value";
+					if ( ! empty( $value ) ) {
+						$value = str_replace( array( '"', "'" ), '', $value );
+
+						$feature_v[]    = "$key '$value'";
+						$permission_v[] = "$key=($value)";
 					}
 				}
 
-				if ( !empty( $v ) ) {
-					$rules .= '    Header set Feature-Policy "' .
-						implode( ';', $v ) . "\"\n";
+				if ( ! empty( $feature_v ) ) {
+					$rules .= '    Header set Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
+				}
+
+				if ( ! empty( $permission_v ) ) {
+					$rules .= '    Header set Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
 				}
 			}
 

--- a/BrowserCache_Environment_Nginx.php
+++ b/BrowserCache_Environment_Nginx.php
@@ -257,17 +257,23 @@ class BrowserCache_Environment_Nginx {
 			if ( $this->c->get_boolean( 'browsercache.security.fp' ) ) {
 				$fp_values = $this->c->get_array( 'browsercache.security.fp.values' );
 
-				$v = array();
+				$feature_v    = array();
+				$permission_v = array();
 				foreach ( $fp_values as $key => $value ) {
-					$value = str_replace( '"', "'", $value );
-					if ( !empty( $value ) ) {
-						$v[] = "$key $value";
+					if ( ! empty( $value ) ) {
+						$value = str_replace( array( '"', "'" ), '', $value );
+
+						$feature_v[]    = "$key '$value'";
+						$permission_v[] = "$key=($value)";
 					}
 				}
 
-				if ( !empty( $v ) ) {
-					$rules[] = 'add_header Feature-Policy "' .
-						implode( ';', $v ) . "\";\n";
+				if ( ! empty( $feature_v ) ) {
+					$rules .= '    Header set Feature-Policy "' . implode( ';', $feature_v ) . "\"\n";
+				}
+
+				if ( ! empty( $permission_v ) ) {
+					$rules .= '    Header set Permissions-Policy "' . implode( ',', $permission_v ) . "\"\n";
 				}
 			}
 		}

--- a/BrowserCache_Page_View_SectionSecurity.php
+++ b/BrowserCache_Page_View_SectionSecurity.php
@@ -791,7 +791,7 @@ $feature_policies = array(
 			'key'            => 'browsercache.security.fp',
 			'disabled'       => Util_Ui::sealing_disabled( 'browsercache.' ),
 			'control'        => 'checkbox',
-			'checkbox_label' => esc_html__( 'Feature-Policy', 'w3-total-cache' ),
+			'checkbox_label' => esc_html__( 'Feature-Policy / Permissions-Policy', 'w3-total-cache' ),
 			'description'    => esc_html__( 'Allows you to control which origins can use which features.', 'w3-total-cache' ),
 			'label_class'    => 'w3tc_single_column',
 		)


### PR DESCRIPTION
To test simply enable the Feature-Policy / Permissions-Policy setting under Browser Cache admin page. Then set the values below that setting to one of the allowed values. Once these are set you can audit a site page request headers to determine if the Feature-Policy and Permissions-Policy headers are present and set. From there you can use a validator tool to analyze a given URL to validate the headers